### PR TITLE
Feature/render images

### DIFF
--- a/index.html
+++ b/index.html
@@ -1063,6 +1063,9 @@
                 } else if (tagName === 'grpSp') {
                     // Note: a full implementation would need to get the returned dimensions of the group
                     await processGroupShape(element, konvaGroup, layoutPlaceholders, slideContext, imageMap, listCounters, { x: offsetX, y: 0 }, defaultTextStyles);
+                } else if (tagName === 'pic') {
+                    const picDimensions = await processPicture(element, konvaGroup, imageMap, { x: offsetX, y: 0 });
+                    offsetX += picDimensions.width + PADDING;
                 }
             }
         }
@@ -1394,6 +1397,59 @@
             });
         }
 
+        async function processPicture(picNode, layer, imageMap, parentXfrm) {
+            const PML_NS = "http://schemas.openxmlformats.org/presentationml/2006/main";
+            const DML_NS = "http://schemas.openxmlformats.org/drawingml/2006/main";
+
+            // 1. Get position and size from spPr -> xfrm
+            let pos = null;
+            const spPrNode = picNode.getElementsByTagNameNS(PML_NS, 'spPr')[0];
+            if (spPrNode) {
+                const xfrmNode = spPrNode.getElementsByTagNameNS(DML_NS, 'xfrm')[0];
+                if (xfrmNode) {
+                    const offNode = xfrmNode.getElementsByTagNameNS(DML_NS, 'off')[0];
+                    const extNode = xfrmNode.getElementsByTagNameNS(DML_NS, 'ext')[0];
+                    if (offNode && extNode) {
+                        pos = {
+                            x: (parseInt(offNode.getAttribute("x")) / EMU_PER_PIXEL) + parentXfrm.x,
+                            y: (parseInt(offNode.getAttribute("y")) / EMU_PER_PIXEL) + parentXfrm.y,
+                            width: parseInt(extNode.getAttribute("cx")) / EMU_PER_PIXEL,
+                            height: parseInt(extNode.getAttribute("cy")) / EMU_PER_PIXEL,
+                        };
+                    }
+                }
+            }
+            if (!pos) return { width: 0, height: 0 };
+
+            // 2. Get image relationship ID from blipFill -> blip
+            const blipFillNode = picNode.getElementsByTagNameNS(PML_NS, 'blipFill')[0];
+            if (!blipFillNode) return { width: 0, height: 0 };
+
+            const blipNode = blipFillNode.getElementsByTagNameNS(DML_NS, 'blip')[0];
+            if (!blipNode) return { width: 0, height: 0 };
+
+            const relId = blipNode.getAttribute('r:embed');
+            if (!relId || !imageMap[relId]) return { width: 0, height: 0 };
+
+            // 3. Create Konva Image
+            try {
+                const imageObj = await createImage(imageMap[relId]);
+                const konvaImage = new Konva.Image({
+                    x: pos.x,
+                    y: pos.y,
+                    image: imageObj,
+                    width: pos.width,
+                    height: pos.height,
+                });
+                layer.add(konvaImage);
+            } catch (e) {
+                console.error("Error creating image", e);
+            }
+
+
+            return { width: pos.width, height: pos.height };
+        }
+
         async function renderSlide( slideXml, slideContainer, layoutPlaceholders, slideNum, slideSize, defaultTextStyles, imageMap, scale, slideContext, finalBg, showMasterShapes ) {
             const parser = new DOMParser();
             const xmlDoc = parser.parseFromString( slideXml, "application/xml" );
@@ -1451,6 +1507,8 @@
                         if (graphicData && graphicData.getAttribute('uri') === 'http://schemas.openxmlformats.org/drawingml/2006/table') {
                             await processTable(element, mainLayer, slideContext);
                         }
+                    } else if (tagName === 'pic') {
+                        await processPicture(element, mainLayer, imageMap, { x: 0, y: 0 });
                     }
                 }
             }

--- a/index.html
+++ b/index.html
@@ -1064,7 +1064,7 @@
                     // Note: a full implementation would need to get the returned dimensions of the group
                     await processGroupShape(element, konvaGroup, layoutPlaceholders, slideContext, imageMap, listCounters, { x: offsetX, y: 0 }, defaultTextStyles);
                 } else if (tagName === 'pic') {
-                    const picDimensions = await processPicture(element, konvaGroup, imageMap, { x: offsetX, y: 0 });
+                    const picDimensions = await processPicture(element, konvaGroup, imageMap, { x: offsetX, y: 0 }, layoutPlaceholders);
                     offsetX += picDimensions.width + PADDING;
                 }
             }
@@ -1397,31 +1397,49 @@
             });
         }
 
-        async function processPicture(picNode, layer, imageMap, parentXfrm) {
+        async function processPicture(picNode, layer, imageMap, parentXfrm, layoutPlaceholders) {
             const PML_NS = "http://schemas.openxmlformats.org/presentationml/2006/main";
             const DML_NS = "http://schemas.openxmlformats.org/drawingml/2006/main";
 
-            // 1. Get position and size from spPr -> xfrm
             let pos = null;
+
+            // 1. Try to get transform from the picture element itself
             const spPrNode = picNode.getElementsByTagNameNS(PML_NS, 'spPr')[0];
-            if (spPrNode) {
-                const xfrmNode = spPrNode.getElementsByTagNameNS(DML_NS, 'xfrm')[0];
-                if (xfrmNode) {
-                    const offNode = xfrmNode.getElementsByTagNameNS(DML_NS, 'off')[0];
-                    const extNode = xfrmNode.getElementsByTagNameNS(DML_NS, 'ext')[0];
-                    if (offNode && extNode) {
-                        pos = {
-                            x: (parseInt(offNode.getAttribute("x")) / EMU_PER_PIXEL) + parentXfrm.x,
-                            y: (parseInt(offNode.getAttribute("y")) / EMU_PER_PIXEL) + parentXfrm.y,
-                            width: parseInt(extNode.getAttribute("cx")) / EMU_PER_PIXEL,
-                            height: parseInt(extNode.getAttribute("cy")) / EMU_PER_PIXEL,
-                        };
+            const xfrmNode = spPrNode ? spPrNode.getElementsByTagNameNS(DML_NS, 'xfrm')[0] : null;
+
+            if (xfrmNode) {
+                const offNode = xfrmNode.getElementsByTagNameNS(DML_NS, 'off')[0];
+                const extNode = xfrmNode.getElementsByTagNameNS(DML_NS, 'ext')[0];
+                if (offNode && extNode) {
+                    pos = {
+                        x: (parseInt(offNode.getAttribute("x")) / EMU_PER_PIXEL) + parentXfrm.x,
+                        y: (parseInt(offNode.getAttribute("y")) / EMU_PER_PIXEL) + parentXfrm.y,
+                        width: parseInt(extNode.getAttribute("cx")) / EMU_PER_PIXEL,
+                        height: parseInt(extNode.getAttribute("cy")) / EMU_PER_PIXEL,
+                    };
+                }
+            } else {
+                // 2. If no transform, look for a placeholder and get transform from layout
+                const nvPicPrNode = picNode.getElementsByTagNameNS(PML_NS, 'nvPicPr')[0];
+                const nvPrNode = nvPicPrNode ? nvPicPrNode.getElementsByTagNameNS(PML_NS, 'nvPr')[0] : null;
+                const phNode = nvPrNode ? nvPrNode.getElementsByTagNameNS(PML_NS, 'ph')[0] : null;
+
+                if (phNode && layoutPlaceholders) {
+                    const phType = phNode.getAttribute('type');
+                    const phIdx = phNode.getAttribute('idx');
+                    const phKey = phIdx ? `idx_${phIdx}` : phType;
+
+                    if (layoutPlaceholders[phKey]) {
+                        pos = { ...layoutPlaceholders[phKey].pos }; // Clone from layout
+                        pos.x += parentXfrm.x;
+                        pos.y += parentXfrm.y;
                     }
                 }
             }
+
             if (!pos) return { width: 0, height: 0 };
 
-            // 2. Get image relationship ID from blipFill -> blip
+            // 3. Get image relationship ID from blipFill -> blip
             const blipFillNode = picNode.getElementsByTagNameNS(PML_NS, 'blipFill')[0];
             if (!blipFillNode) return { width: 0, height: 0 };
 
@@ -1431,7 +1449,7 @@
             const relId = blipNode.getAttribute('r:embed');
             if (!relId || !imageMap[relId]) return { width: 0, height: 0 };
 
-            // 3. Create Konva Image
+            // 4. Create Konva Image
             try {
                 const imageObj = await createImage(imageMap[relId]);
                 const konvaImage = new Konva.Image({
@@ -1445,7 +1463,6 @@
             } catch (e) {
                 console.error("Error creating image", e);
             }
-
 
             return { width: pos.width, height: pos.height };
         }
@@ -1508,7 +1525,7 @@
                             await processTable(element, mainLayer, slideContext);
                         }
                     } else if (tagName === 'pic') {
-                        await processPicture(element, mainLayer, imageMap, { x: 0, y: 0 });
+                        await processPicture(element, mainLayer, imageMap, { x: 0, y: 0 }, layoutPlaceholders);
                     }
                 }
             }


### PR DESCRIPTION
fix: Correctly render images from placeholders

This commit fixes an issue where images placed in slide layout placeholders were not being rendered. The previous implementation only looked for position and size information directly within the slide's `<p:pic>` element.

The key changes include:
- The `processPicture` function has been improved to handle image rendering by first checking for transform properties on the `<p:pic>` element itself.
- If no transform is found, the function now inspects the `<p:pic>` element for a placeholder tag (`<p:ph>`).
- If a placeholder is found, it uses the placeholder's index or type to retrieve the correct position and size from the slide layout's data.
- The `renderSlide` and `processGroupShape` functions have been updated to pass the necessary `layoutPlaceholders` data to the `processPicture` function.

This ensures that images are rendered correctly, whether they are placed directly on the slide or inserted into a placeholder defined in a slide layout or master.