### PR TITLE
Feat/render custom shapes

### DIFF
--- a/index.html
+++ b/index.html
@@ -1128,6 +1128,11 @@
                 if (solidFillNode) {
                     properties.defRPr.color = parseColor(solidFillNode);
                 }
+
+                const latinFontNode = defRPrNode.getElementsByTagNameNS( DML_NS, 'latin' )[ 0 ];
+                if ( latinFontNode && latinFontNode.getAttribute( 'typeface' ) ) {
+                    properties.defRPr.font = latinFontNode.getAttribute( 'typeface' );
+                }
             }
 
             return properties;
@@ -1292,6 +1297,10 @@
                             if (rPr.getAttribute('i') === '1') finalRunProps.italic = true; else if (rPr.getAttribute('i') === '0') finalRunProps.italic = false;
                             const solidFill = rPr.getElementsByTagNameNS(DML_NS, 'solidFill')[0];
                             if (solidFill) finalRunProps.color = parseColor(solidFill);
+                            const latinFontNode = rPr.getElementsByTagNameNS( DML_NS, 'latin' )[ 0 ];
+                            if ( latinFontNode && latinFontNode.getAttribute( 'typeface' ) ) {
+                                finalRunProps.font = latinFontNode.getAttribute( 'typeface' );
+                            }
                         }
 
                         const textColor = resolveColor(finalRunProps.color, slideContext) || '#000000';
@@ -1353,6 +1362,11 @@
                     phType = placeholder.getAttribute('type');
                     const phIdx = placeholder.getAttribute('idx');
                     phKey = phIdx ? `idx_${phIdx}` : phType;
+
+                    // If no type is specified but an index is, it's usually a body/content placeholder.
+                    if ( !phType && phIdx ) {
+                        phType = 'body';
+                    }
                 }
             }
 


### PR DESCRIPTION
fix: Correct text layout calculation for multiple text runs

This commit fixes a critical bug where paragraphs containing multiple text runs (`<a:r>`) would only render the first run.

The issue was caused by using the incorrect Konva.js method to measure the size of a text run. The code was using `.width()` and `.height()`, which return the size of the text box, not the text itself. This caused the position for subsequent text runs to be calculated incorrectly, pushing them outside the visible area.

The fix replaces these calls with `.getTextWidth()` and `.getTextHeight()`, which return the actual dimensions of the rendered text. This ensures that multiple text runs within the same paragraph are positioned correctly side-by-side.