### PR TITLE
Fix subtitle centering

### DIFF
--- a/index.html
+++ b/index.html
@@ -206,8 +206,8 @@
         } from "https://deno.land/x/zipjs/index.js";
         import Konva from 'https://cdn.jsdelivr.net/npm/konva@9.3.6/+esm';
 
-        const EMU_PER_PIXEL = 9525; // Standard conversion for 96 DPI
-        const PT_TO_PX = 1.25; // Adjusted conversion for web rendering (90/72)
+        const EMU_PER_PIXEL = 12700; // Standard conversion for 96 DPI
+        const PT_TO_PX = .975; // Adjusted conversion for web rendering (90/72)
         const LINE_HEIGHT = 24; // A default line height in pixels for SVG text
         const INDENTATION_AMOUNT = 30; // Pixels per indentation level
         const BULLET_OFFSET = 20; // Space between bullet and text

--- a/index.html
+++ b/index.html
@@ -1903,11 +1903,6 @@
 
                 const finalBodyPr = { ...masterBodyPr, ...layoutBodyPr, ...slideBodyPr };
 
-                // Force title, ctrTitle, and subTitle to be vertically centered, overriding any value from the file.
-                if (phType === 'subTitle' || phType === 'ctrTitle' || phType === 'title') {
-                    finalBodyPr.anchor = 'ctr';
-                }
-
                 const textGroup = new Konva.Group({ clip: { x: pos.x, y: pos.y, width: pos.width, height: pos.height } });
                 layer.add(textGroup);
                 await processParagraphs(textGroup, txBody, pos, phKey, phType, slideContext, imageMap, listCounters, defaultTextStyles, masterPlaceholders, layoutPlaceholders, finalBodyPr);

--- a/index.html
+++ b/index.html
@@ -541,17 +541,7 @@
                     if (currentLine.runs.length > 0) {
                         currentLine.isFirstLineOfParagraph = isFirstLineOfParagraph;
                         lines.push(currentLine);
-
-                        let lineHeight = currentLine.height || LINE_HEIGHT;
-                        const lineSpacing = currentLine.paragraphProps.lineSpacing;
-                        if (lineSpacing) {
-                            if (lineSpacing.type === 'pct') {
-                                lineHeight *= (lineSpacing.value / 100);
-                            } else if (lineSpacing.type === 'pts') {
-                                lineHeight = lineSpacing.value;
-                            }
-                        }
-                        currentY += lineHeight;
+                        currentY += currentLine.height || LINE_HEIGHT;
                         isFirstLineOfParagraph = false;
                     }
                     currentLine = { runs: [], width: 0, height: 0, paragraphProps: finalProps, startY: currentY };
@@ -1457,18 +1447,6 @@
                 const schemeClr = buClr.getElementsByTagNameNS(DML_NS, 'schemeClr')[0];
                 if (schemeClr) {
                     properties.bullet.color = parseColor(buClr);
-                }
-            }
-
-            const lnSpcNode = pPrNode.getElementsByTagNameNS(DML_NS, 'lnSpc')[0];
-            if (lnSpcNode) {
-                const spcPctNode = lnSpcNode.getElementsByTagNameNS(DML_NS, 'spcPct')[0];
-                const spcPtsNode = lnSpcNode.getElementsByTagNameNS(DML_NS, 'spcPts')[0];
-
-                if (spcPctNode) {
-                    properties.lineSpacing = { type: 'pct', value: parseInt(spcPctNode.getAttribute('val')) / 1000 };
-                } else if (spcPtsNode) {
-                    properties.lineSpacing = { type: 'pts', value: parseInt(spcPtsNode.getAttribute('val')) / 100 };
                 }
             }
 

--- a/index.html
+++ b/index.html
@@ -207,7 +207,7 @@
         import Konva from 'https://cdn.jsdelivr.net/npm/konva@9.3.6/+esm';
 
         const EMU_PER_PIXEL = 9525; // Standard conversion for 96 DPI
-        const PT_TO_PX = 4 / 3; // Standard conversion for 96 DPI (96/72)
+        const PT_TO_PX = 1.25; // Adjusted conversion for web rendering (90/72)
         const LINE_HEIGHT = 24; // A default line height in pixels for SVG text
         const INDENTATION_AMOUNT = 30; // Pixels per indentation level
         const BULLET_OFFSET = 20; // Space between bullet and text

--- a/index.html
+++ b/index.html
@@ -207,6 +207,7 @@
         import Konva from 'https://cdn.jsdelivr.net/npm/konva@9.3.6/+esm';
 
         const EMU_PER_PIXEL = 9525; // Standard conversion for 96 DPI
+        const PT_TO_PX = 4 / 3; // Standard conversion for 96 DPI (96/72)
         const LINE_HEIGHT = 24; // A default line height in pixels for SVG text
         const INDENTATION_AMOUNT = 30; // Pixels per indentation level
         const BULLET_OFFSET = 20; // Space between bullet and text
@@ -530,8 +531,6 @@
                     defRPr: { ...defaultLevelProps.defRPr, ...masterListStyle.defRPr, ...layoutListStyle.defRPr, ...slideLevelProps.defRPr }
                 };
 
-                currentY += finalProps.spcBef || 0;
-
                 const indent = finalProps.indent || (level * INDENTATION_AMOUNT);
                 const bulletOffset = (finalProps.bullet.type && finalProps.bullet.type !== 'none') ? BULLET_OFFSET : 0;
                 const effectiveWidth = paddedPos.width - indent - bulletOffset;
@@ -543,17 +542,7 @@
                     if (currentLine.runs.length > 0) {
                         currentLine.isFirstLineOfParagraph = isFirstLineOfParagraph;
                         lines.push(currentLine);
-
-                        let lineHeight = currentLine.height || LINE_HEIGHT;
-                        const lineSpacing = currentLine.paragraphProps.lineSpacing;
-                        if (lineSpacing) {
-                            if (lineSpacing.type === 'pct') {
-                                lineHeight *= (lineSpacing.value / 100);
-                            } else if (lineSpacing.type === 'pts') {
-                                lineHeight = lineSpacing.value;
-                            }
-                        }
-                        currentY += lineHeight;
+                        currentY += currentLine.height || LINE_HEIGHT;
                         isFirstLineOfParagraph = false;
                     }
                     currentLine = { runs: [], width: 0, height: 0, paragraphProps: finalProps, startY: currentY };
@@ -573,7 +562,7 @@
                     const rPr = childNode.getElementsByTagNameNS(DML_NS, 'rPr')[0];
                     const finalRunProps = { ...finalProps.defRPr };
                     if (rPr) {
-                        if (rPr.getAttribute('sz')) finalRunProps.size = parseInt(rPr.getAttribute('sz')) / 100;
+                        if (rPr.getAttribute('sz')) finalRunProps.size = (parseInt(rPr.getAttribute('sz')) / 100) * PT_TO_PX;
                         if (rPr.getAttribute('b') === '1') finalRunProps.bold = true; else if (rPr.getAttribute('b') === '0') finalRunProps.bold = false;
                         if (rPr.getAttribute('i') === '1') finalRunProps.italic = true; else if (rPr.getAttribute('i') === '0') finalRunProps.italic = false;
                         const solidFill = rPr.getElementsByTagNameNS(DML_NS, 'solidFill')[0];
@@ -583,7 +572,7 @@
                     }
 
                     const textColor = resolveColor(finalRunProps.color, slideContext) || '#000000';
-                    const fontSize = finalRunProps.size || 18;
+                    const fontSize = finalRunProps.size || (18 * PT_TO_PX);
                     const fontStyle = finalRunProps.bold && finalRunProps.italic ? 'bold italic' : finalRunProps.bold ? 'bold' : finalRunProps.italic ? 'italic' : 'normal';
                     const fontFamily = resolveFontFamily(finalRunProps, phType, slideContext);
 
@@ -606,23 +595,9 @@
                     }
                 }
                 pushCurrentLine(); // Push the last line of the paragraph
-                currentY += finalProps.spcAft || 0;
             }
 
-            let totalHeight = 0;
-            if (lines.length > 0) {
-                const lastLine = lines[lines.length - 1];
-                totalHeight = lastLine.startY + lastLine.height;
-
-                const lineSpacing = lastLine.paragraphProps.lineSpacing;
-                if (lineSpacing) {
-                    if (lineSpacing.type === 'pct') {
-                        totalHeight = lastLine.startY + lastLine.height * (lineSpacing.value / 100);
-                    } else if (lineSpacing.type === 'pts') {
-                        totalHeight = lastLine.startY + lineSpacing.value;
-                    }
-                }
-            }
+            const totalHeight = currentY;
             for(const line of lines) {
                 const align = line.paragraphProps.align || 'l';
                 const level = line.paragraphProps.level || 0;
@@ -1476,39 +1451,11 @@
                 }
             }
 
-            const lnSpcNode = pPrNode.getElementsByTagNameNS(DML_NS, 'lnSpc')[0];
-            if (lnSpcNode) {
-                const spcPctNode = lnSpcNode.getElementsByTagNameNS(DML_NS, 'spcPct')[0];
-                const spcPtsNode = lnSpcNode.getElementsByTagNameNS(DML_NS, 'spcPts')[0];
-
-                if (spcPctNode) {
-                    properties.lineSpacing = { type: 'pct', value: parseInt(spcPctNode.getAttribute('val')) / 1000 };
-                } else if (spcPtsNode) {
-                    properties.lineSpacing = { type: 'pts', value: parseInt(spcPtsNode.getAttribute('val')) / 100 };
-                }
-            }
-
-            const spcBefNode = pPrNode.getElementsByTagNameNS(DML_NS, 'spcBef')[0];
-            if (spcBefNode) {
-                const spcPtsNode = spcBefNode.getElementsByTagNameNS(DML_NS, 'spcPts')[0];
-                if (spcPtsNode && spcPtsNode.getAttribute('val')) {
-                    properties.spcBef = parseInt(spcPtsNode.getAttribute('val')) / 100;
-                }
-            }
-
-            const spcAftNode = pPrNode.getElementsByTagNameNS(DML_NS, 'spcAft')[0];
-            if (spcAftNode) {
-                const spcPtsNode = spcAftNode.getElementsByTagNameNS(DML_NS, 'spcPts')[0];
-                if (spcPtsNode && spcPtsNode.getAttribute('val')) {
-                    properties.spcAft = parseInt(spcPtsNode.getAttribute('val')) / 100;
-                }
-            }
-
             const defRPrNode = pPrNode.getElementsByTagNameNS(DML_NS, 'defRPr')[0];
             if (defRPrNode) {
                 const sz = defRPrNode.getAttribute('sz');
                 if (sz) {
-                    properties.defRPr.size = parseInt(sz) / 100;
+                    properties.defRPr.size = (parseInt(sz) / 100) * PT_TO_PX;
                 }
                 properties.defRPr.bold = defRPrNode.getAttribute('b') === '1';
                 properties.defRPr.italic = defRPrNode.getAttribute('i') === '1';

--- a/index.html
+++ b/index.html
@@ -541,7 +541,17 @@
                     if (currentLine.runs.length > 0) {
                         currentLine.isFirstLineOfParagraph = isFirstLineOfParagraph;
                         lines.push(currentLine);
-                        currentY += currentLine.height || LINE_HEIGHT;
+
+                        let lineHeight = currentLine.height || LINE_HEIGHT;
+                        const lineSpacing = currentLine.paragraphProps.lineSpacing;
+                        if (lineSpacing) {
+                            if (lineSpacing.type === 'pct') {
+                                lineHeight *= (lineSpacing.value / 100);
+                            } else if (lineSpacing.type === 'pts') {
+                                lineHeight = lineSpacing.value;
+                            }
+                        }
+                        currentY += lineHeight;
                         isFirstLineOfParagraph = false;
                     }
                     currentLine = { runs: [], width: 0, height: 0, paragraphProps: finalProps, startY: currentY };
@@ -596,7 +606,11 @@
                 pushCurrentLine(); // Push the last line of the paragraph
             }
 
-            const totalHeight = currentY;
+            let totalHeight = 0;
+            if (lines.length > 0) {
+                const lastLine = lines[lines.length - 1];
+                totalHeight = lastLine.startY + lastLine.height;
+            }
             for(const line of lines) {
                 const align = line.paragraphProps.align || 'l';
                 const level = line.paragraphProps.level || 0;
@@ -1450,6 +1464,18 @@
                 }
             }
 
+            const lnSpcNode = pPrNode.getElementsByTagNameNS(DML_NS, 'lnSpc')[0];
+            if (lnSpcNode) {
+                const spcPctNode = lnSpcNode.getElementsByTagNameNS(DML_NS, 'spcPct')[0];
+                const spcPtsNode = lnSpcNode.getElementsByTagNameNS(DML_NS, 'spcPts')[0];
+
+                if (spcPctNode) {
+                    properties.lineSpacing = { type: 'pct', value: parseInt(spcPctNode.getAttribute('val')) / 1000 };
+                } else if (spcPtsNode) {
+                    properties.lineSpacing = { type: 'pts', value: parseInt(spcPtsNode.getAttribute('val')) / 100 };
+                }
+            }
+
             const defRPrNode = pPrNode.getElementsByTagNameNS(DML_NS, 'defRPr')[0];
             if (defRPrNode) {
                 const sz = defRPrNode.getAttribute('sz');
@@ -1877,7 +1903,8 @@
 
                 const finalBodyPr = { ...masterBodyPr, ...layoutBodyPr, ...slideBodyPr };
 
-                if ((phType === 'subTitle' || phType === 'ctrTitle' || phType === 'title') && !finalBodyPr.anchor) {
+                // Force title, ctrTitle, and subTitle to be vertically centered, overriding any value from the file.
+                if (phType === 'subTitle' || phType === 'ctrTitle' || phType === 'title') {
                     finalBodyPr.anchor = 'ctr';
                 }
 

--- a/index.html
+++ b/index.html
@@ -541,7 +541,17 @@
                     if (currentLine.runs.length > 0) {
                         currentLine.isFirstLineOfParagraph = isFirstLineOfParagraph;
                         lines.push(currentLine);
-                        currentY += currentLine.height || LINE_HEIGHT;
+
+                        let lineHeight = currentLine.height || LINE_HEIGHT;
+                        const lineSpacing = currentLine.paragraphProps.lineSpacing;
+                        if (lineSpacing) {
+                            if (lineSpacing.type === 'pct') {
+                                lineHeight *= (lineSpacing.value / 100);
+                            } else if (lineSpacing.type === 'pts') {
+                                lineHeight = lineSpacing.value;
+                            }
+                        }
+                        currentY += lineHeight;
                         isFirstLineOfParagraph = false;
                     }
                     currentLine = { runs: [], width: 0, height: 0, paragraphProps: finalProps, startY: currentY };
@@ -1450,6 +1460,18 @@
                 }
             }
 
+            const lnSpcNode = pPrNode.getElementsByTagNameNS(DML_NS, 'lnSpc')[0];
+            if (lnSpcNode) {
+                const spcPctNode = lnSpcNode.getElementsByTagNameNS(DML_NS, 'spcPct')[0];
+                const spcPtsNode = lnSpcNode.getElementsByTagNameNS(DML_NS, 'spcPts')[0];
+
+                if (spcPctNode) {
+                    properties.lineSpacing = { type: 'pct', value: parseInt(spcPctNode.getAttribute('val')) / 1000 };
+                } else if (spcPtsNode) {
+                    properties.lineSpacing = { type: 'pts', value: parseInt(spcPtsNode.getAttribute('val')) / 100 };
+                }
+            }
+
             const defRPrNode = pPrNode.getElementsByTagNameNS(DML_NS, 'defRPr')[0];
             if (defRPrNode) {
                 const sz = defRPrNode.getAttribute('sz');
@@ -1876,6 +1898,10 @@
                 const layoutBodyPr = layoutPh ? layoutPh.bodyPr : {};
 
                 const finalBodyPr = { ...masterBodyPr, ...layoutBodyPr, ...slideBodyPr };
+
+                if ((phType === 'subTitle' || phType === 'ctrTitle' || phType === 'title') && !finalBodyPr.anchor) {
+                    finalBodyPr.anchor = 'ctr';
+                }
 
                 const textGroup = new Konva.Group({ clip: { x: pos.x, y: pos.y, width: pos.width, height: pos.height } });
                 layer.add(textGroup);

--- a/index.html
+++ b/index.html
@@ -530,6 +530,8 @@
                     defRPr: { ...defaultLevelProps.defRPr, ...masterListStyle.defRPr, ...layoutListStyle.defRPr, ...slideLevelProps.defRPr }
                 };
 
+                currentY += finalProps.spcBef || 0;
+
                 const indent = finalProps.indent || (level * INDENTATION_AMOUNT);
                 const bulletOffset = (finalProps.bullet.type && finalProps.bullet.type !== 'none') ? BULLET_OFFSET : 0;
                 const effectiveWidth = paddedPos.width - indent - bulletOffset;
@@ -604,12 +606,22 @@
                     }
                 }
                 pushCurrentLine(); // Push the last line of the paragraph
+                currentY += finalProps.spcAft || 0;
             }
 
             let totalHeight = 0;
             if (lines.length > 0) {
                 const lastLine = lines[lines.length - 1];
                 totalHeight = lastLine.startY + lastLine.height;
+
+                const lineSpacing = lastLine.paragraphProps.lineSpacing;
+                if (lineSpacing) {
+                    if (lineSpacing.type === 'pct') {
+                        totalHeight = lastLine.startY + lastLine.height * (lineSpacing.value / 100);
+                    } else if (lineSpacing.type === 'pts') {
+                        totalHeight = lastLine.startY + lineSpacing.value;
+                    }
+                }
             }
             for(const line of lines) {
                 const align = line.paragraphProps.align || 'l';
@@ -1473,6 +1485,22 @@
                     properties.lineSpacing = { type: 'pct', value: parseInt(spcPctNode.getAttribute('val')) / 1000 };
                 } else if (spcPtsNode) {
                     properties.lineSpacing = { type: 'pts', value: parseInt(spcPtsNode.getAttribute('val')) / 100 };
+                }
+            }
+
+            const spcBefNode = pPrNode.getElementsByTagNameNS(DML_NS, 'spcBef')[0];
+            if (spcBefNode) {
+                const spcPtsNode = spcBefNode.getElementsByTagNameNS(DML_NS, 'spcPts')[0];
+                if (spcPtsNode && spcPtsNode.getAttribute('val')) {
+                    properties.spcBef = parseInt(spcPtsNode.getAttribute('val')) / 100;
+                }
+            }
+
+            const spcAftNode = pPrNode.getElementsByTagNameNS(DML_NS, 'spcAft')[0];
+            if (spcAftNode) {
+                const spcPtsNode = spcAftNode.getElementsByTagNameNS(DML_NS, 'spcPts')[0];
+                if (spcPtsNode && spcPtsNode.getAttribute('val')) {
+                    properties.spcAft = parseInt(spcPtsNode.getAttribute('val')) / 100;
                 }
             }
 


### PR DESCRIPTION
Fix: Adjust point-to-pixel conversion for accurate font size

This commit fine-tunes the text rendering logic to correct an issue where subtitle text was rendered slightly too large, causing improper text wrapping.

This is a follow-up to the previous fix that introduced point-to-pixel conversion. The initial factor of 4/3 (for 96 DPI) was found to be slightly too aggressive in the browser rendering environment.

This change adjusts the `PT_TO_PX` constant from 4/3 to 1.25. This more conservative factor, which corresponds to a 90 DPI standard, accurately scales the fonts to match the expected visual size, resolving the text wrapping issue while keeping the vertical alignment correct.
