### PR TITLE
Fix line rendering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ yarn-error.log*
 
 # Environment files (local configs)
 /.env.*
+/.vim*
 
 # Jules' temporary verification files
 /jules-scratch/

--- a/index.html
+++ b/index.html
@@ -1301,7 +1301,23 @@
 
             const prstGeomNode = spPrNode.getElementsByTagNameNS(DML_NS, 'prstGeom')[0];
             if (prstGeomNode) {
-                properties.geometry = { type: 'preset', preset: prstGeomNode.getAttribute('prst') };
+                const avLstNode = prstGeomNode.getElementsByTagNameNS(DML_NS, 'avLst')[0];
+                const adjustments = {};
+                if (avLstNode) {
+                    const gdNodes = avLstNode.getElementsByTagNameNS(DML_NS, 'gd');
+                    for (const gdNode of gdNodes) {
+                        const name = gdNode.getAttribute('name');
+                        const fmla = gdNode.getAttribute('fmla');
+                        if (fmla.startsWith('val ')) {
+                            adjustments[name] = parseInt(fmla.substring(4));
+                        }
+                    }
+                }
+                properties.geometry = {
+                    type: 'preset',
+                    preset: prstGeomNode.getAttribute('prst'),
+                    adjustments: adjustments,
+                };
             }
 
             const custGeomNode = spPrNode.getElementsByTagNameNS(DML_NS, 'custGeom')[0];

--- a/index.html
+++ b/index.html
@@ -1218,9 +1218,15 @@
             const noFillNode = lnNode.getElementsByTagNameNS(DML_NS, 'noFill')[0];
             if (noFillNode) return null;
 
+            const capMap = {
+                rnd: 'round',
+                sq: 'square',
+                flat: 'butt'
+            };
+
             const props = {
                 width: parseInt(lnNode.getAttribute('w') || '9525') / EMU_PER_PIXEL,
-                cap: lnNode.getAttribute('cap'), // rnd, sq, flat
+                cap: capMap[lnNode.getAttribute('cap')] || 'butt',
                 join: null // miter, round, bevel
             };
 
@@ -1236,18 +1242,40 @@
             const prstDashNode = lnNode.getElementsByTagNameNS(DML_NS, 'prstDash')[0];
             if (prstDashNode) {
                 const dashType = prstDashNode.getAttribute('val') || 'solid';
+                const w = props.width;
                 switch (dashType) {
                     case 'solid':
                         props.dash = [];
                         break;
                     case 'dot':
-                        props.dash = [1, 5];
+                        props.dash = [w, 3 * w];
                         break;
                     case 'dash':
-                        props.dash = [10, 5];
+                        props.dash = [4 * w, 3 * w];
                         break;
                     case 'lgDash':
-                        props.dash = [20, 10];
+                        props.dash = [8 * w, 3 * w];
+                        break;
+                    case 'dashDot':
+                        props.dash = [4 * w, 3 * w, w, 3 * w];
+                        break;
+                    case 'lgDashDot':
+                        props.dash = [8 * w, 3 * w, w, 3 * w];
+                        break;
+                    case 'lgDashDotDot':
+                        props.dash = [8 * w, 3 * w, w, 3 * w, w, 3 * w];
+                        break;
+                    case 'sysDash':
+                        props.dash = [3 * w, w];
+                        break;
+                    case 'sysDot':
+                        props.dash = [w, w];
+                        break;
+                    case 'sysDashDot':
+                        props.dash = [3 * w, w, w, w];
+                        break;
+                    case 'sysDashDotDot':
+                        props.dash = [3 * w, w, w, w, w, w];
                         break;
                     default:
                         props.dash = [];

--- a/src/utils/shape-builder.js
+++ b/src/utils/shape-builder.js
@@ -141,7 +141,7 @@ export class ShapeBuilder {
                     break;
                 case 'arc':
                     const arcAdj = shapeProps.geometry.adjustments;
-                    const arcStartAngle = (arcAdj?.adj1 !== undefined ? arcAdj.adj1 : 90) / 60000;
+                    const arcStartAngle = (arcAdj?.adj1 !== undefined ? arcAdj.adj1 : 0) / 60000;
                     const arcSweepAngle = (arcAdj?.adj2 !== undefined ? arcAdj.adj2 : 5400000) / 60000;
                     const arcEndAngle = arcStartAngle + arcSweepAngle;
 
@@ -150,8 +150,8 @@ export class ShapeBuilder {
                     const arcRadiusX = pos.width / 2;
                     const arcRadiusY = pos.height / 2;
 
-                    const arcStart = this.polarToCartesianForArc(arcCenterX, arcCenterY, arcRadiusX, arcRadiusY, arcStartAngle);
-                    const arcEnd = this.polarToCartesianForArc(arcCenterX, arcCenterY, arcRadiusX, arcRadiusY, arcEndAngle);
+                    const arcStart = this.polarToCartesian(arcCenterX, arcCenterY, arcRadiusX, arcRadiusY, arcStartAngle);
+                    const arcEnd = this.polarToCartesian(arcCenterX, arcCenterY, arcRadiusX, arcRadiusY, arcEndAngle);
 
                     const arcLargeArcFlag = arcSweepAngle <= 180 ? "0" : "1";
 
@@ -323,14 +323,6 @@ export class ShapeBuilder {
 
     polarToCartesian(centerX, centerY, radiusX, radiusY, angleInDegrees) {
         const angleInRadians = (angleInDegrees - 180) * Math.PI / 180.0;
-        return {
-            x: centerX + (radiusX * Math.cos(angleInRadians)),
-            y: centerY + (radiusY * Math.sin(angleInRadians))
-        };
-    }
-
-    polarToCartesianForArc(centerX, centerY, radiusX, radiusY, angleInDegrees) {
-        const angleInRadians = angleInDegrees * Math.PI / 180.0;
         return {
             x: centerX + (radiusX * Math.cos(angleInRadians)),
             y: centerY + (radiusY * Math.sin(angleInRadians))

--- a/src/utils/shape-builder.js
+++ b/src/utils/shape-builder.js
@@ -141,7 +141,7 @@ export class ShapeBuilder {
                     break;
                 case 'arc':
                     const arcAdj = shapeProps.geometry.adjustments;
-                    const arcStartAngle = (arcAdj?.adj1 !== undefined ? arcAdj.adj1 : 10800000) / 60000;
+                    const arcStartAngle = (arcAdj?.adj1 !== undefined ? arcAdj.adj1 : 5400000) / 60000;
                     const arcSweepAngle = (arcAdj?.adj2 !== undefined ? arcAdj.adj2 : 5400000) / 60000;
                     const arcEndAngle = arcStartAngle + arcSweepAngle;
 
@@ -150,8 +150,8 @@ export class ShapeBuilder {
                     const arcRadiusX = pos.width / 2;
                     const arcRadiusY = pos.height / 2;
 
-                    const arcStart = this.polarToCartesian(arcCenterX, arcCenterY, arcRadiusX, arcRadiusY, arcStartAngle);
-                    const arcEnd = this.polarToCartesian(arcCenterX, arcCenterY, arcRadiusX, arcRadiusY, arcEndAngle);
+                    const arcStart = this.polarToCartesianForArc(arcCenterX, arcCenterY, arcRadiusX, arcRadiusY, arcStartAngle);
+                    const arcEnd = this.polarToCartesianForArc(arcCenterX, arcCenterY, arcRadiusX, arcRadiusY, arcEndAngle);
 
                     const arcLargeArcFlag = arcSweepAngle <= 180 ? "0" : "1";
 

--- a/src/utils/shape-builder.js
+++ b/src/utils/shape-builder.js
@@ -330,7 +330,7 @@ export class ShapeBuilder {
     }
 
     polarToCartesianForArc(centerX, centerY, radiusX, radiusY, angleInDegrees) {
-        const angleInRadians = angleInDegrees * Math.PI / 180.0;
+        const angleInRadians = -angleInDegrees * Math.PI / 180.0;
         return {
             x: centerX + (radiusX * Math.cos(angleInRadians)),
             y: centerY + (radiusY * Math.sin(angleInRadians))

--- a/src/utils/shape-builder.js
+++ b/src/utils/shape-builder.js
@@ -330,10 +330,10 @@ export class ShapeBuilder {
     }
 
     polarToCartesianForArc(centerX, centerY, radiusX, radiusY, angleInDegrees) {
-        const angleInRadians = -angleInDegrees * Math.PI / 180.0;
+        const angleInRadians = angleInDegrees * Math.PI / 180.0;
         return {
-            x: centerX + (radiusX * Math.cos(angleInRadians)),
-            y: centerY + (radiusY * Math.sin(angleInRadians))
+            x: centerX - (radiusX * Math.cos(angleInRadians)),
+            y: centerY - (radiusY * Math.sin(angleInRadians))
         };
     }
 }

--- a/src/utils/shape-builder.js
+++ b/src/utils/shape-builder.js
@@ -104,13 +104,6 @@ export class ShapeBuilder {
 
         const txBody = shapeNode.getElementsByTagNameNS(PML_NS, 'txBody')[0];
 
-        if (shapeName === 'Straight Connector 11' || shapeName === 'Arc 21') {
-            console.log(`[DEBUG] Shape: ${shapeName}`);
-            console.log(`[DEBUG] Position:`, JSON.stringify(pos, null, 2));
-            console.log(`[DEBUG] Final Matrix:`, finalMatrix.m);
-            console.log(`[DEBUG] Stroke Properties:`, JSON.stringify(shapeProps.stroke, null, 2));
-        }
-
         if (shapeProps && shapeProps.geometry) {
              const geomType = shapeProps.geometry.type === 'preset' ? shapeProps.geometry.preset : shapeProps.geometry.type;
              switch (geomType) {
@@ -148,14 +141,9 @@ export class ShapeBuilder {
                     break;
                 case 'arc':
                     const arcAdj = shapeProps.geometry.adjustments;
-                    const arcStartAngle = (arcAdj?.adj1 !== undefined ? arcAdj.adj1 : 16200000) / 60000;
+                    const arcStartAngle = (arcAdj?.adj1 !== undefined ? arcAdj.adj1 : 10800000) / 60000;
                     const arcSweepAngle = (arcAdj?.adj2 !== undefined ? arcAdj.adj2 : 5400000) / 60000;
                     const arcEndAngle = arcStartAngle + arcSweepAngle;
-
-                    if (shapeName === 'Arc 21') {
-                        console.log(`[DEBUG] Arc Start Angle: ${arcStartAngle}`);
-                        console.log(`[DEBUG] Arc Sweep Angle: ${arcSweepAngle}`);
-                    }
 
                     const arcCenterX = pos.width / 2;
                     const arcCenterY = pos.height / 2;
@@ -171,10 +159,6 @@ export class ShapeBuilder {
                         "M", arcStart.x, arcStart.y,
                         "A", arcRadiusX, arcRadiusY, 0, arcLargeArcFlag, 1, arcEnd.x, arcEnd.y,
                     ].join(" ");
-
-                    if (shapeName === 'Arc 21') {
-                        console.log(`[DEBUG] Arc Path: ${arcPath}`);
-                    }
 
                     this.renderer.drawPath(arcPath, {
                         stroke: shapeProps.stroke,

--- a/src/utils/shape-builder.js
+++ b/src/utils/shape-builder.js
@@ -141,7 +141,7 @@ export class ShapeBuilder {
                     break;
                 case 'arc':
                     const arcAdj = shapeProps.geometry.adjustments;
-                    const arcStartAngle = (arcAdj?.adj1 !== undefined ? arcAdj.adj1 : 0) / 60000;
+                    const arcStartAngle = (arcAdj?.adj1 !== undefined ? arcAdj.adj1 : 10800000) / 60000;
                     const arcSweepAngle = (arcAdj?.adj2 !== undefined ? arcAdj.adj2 : 5400000) / 60000;
                     const arcEndAngle = arcStartAngle + arcSweepAngle;
 

--- a/src/utils/shape-builder.js
+++ b/src/utils/shape-builder.js
@@ -150,7 +150,26 @@ export class ShapeBuilder {
                     this.renderer.setTransform(finalMatrix);
                     break;
                 case 'arc':
-                    const arcPath = `M 0,${pos.height} A ${pos.width},${pos.height} 0 0 1 ${pos.width},0`;
+                    const arcAdj = shapeProps.geometry.adjustments;
+                    const arcStartAngle = (arcAdj?.adj1 !== undefined ? arcAdj.adj1 : 16200000) / 60000;
+                    const arcSweepAngle = (arcAdj?.adj2 !== undefined ? arcAdj.adj2 : 5400000) / 60000;
+                    const arcEndAngle = arcStartAngle + arcSweepAngle;
+
+                    const arcCenterX = pos.width / 2;
+                    const arcCenterY = pos.height / 2;
+                    const arcRadiusX = pos.width / 2;
+                    const arcRadiusY = pos.height / 2;
+
+                    const arcStart = this.polarToCartesian(arcCenterX, arcCenterY, arcRadiusX, arcRadiusY, arcStartAngle);
+                    const arcEnd = this.polarToCartesian(arcCenterX, arcCenterY, arcRadiusX, arcRadiusY, arcEndAngle);
+
+                    const arcLargeArcFlag = arcSweepAngle <= 180 ? "0" : "1";
+
+                    const arcPath = [
+                        "M", arcStart.x, arcStart.y,
+                        "A", arcRadiusX, arcRadiusY, 0, arcLargeArcFlag, 1, arcEnd.x, arcEnd.y,
+                    ].join(" ");
+
                     this.renderer.drawPath(arcPath, {
                         stroke: shapeProps.stroke,
                     });

--- a/src/utils/shape-builder.js
+++ b/src/utils/shape-builder.js
@@ -104,13 +104,6 @@ export class ShapeBuilder {
 
         const txBody = shapeNode.getElementsByTagNameNS(PML_NS, 'txBody')[0];
 
-        if (shapeName === 'Straight Connector 11' || shapeName === 'Arc 21') {
-            console.log(`[DEBUG] Shape: ${shapeName}`);
-            console.log(`[DEBUG] Position:`, JSON.stringify(pos, null, 2));
-            console.log(`[DEBUG] Final Matrix:`, finalMatrix.m);
-            console.log(`[DEBUG] Stroke Properties:`, JSON.stringify(shapeProps.stroke, null, 2));
-        }
-
         if (shapeProps && shapeProps.geometry) {
              const geomType = shapeProps.geometry.type === 'preset' ? shapeProps.geometry.preset : shapeProps.geometry.type;
              switch (geomType) {
@@ -148,33 +141,24 @@ export class ShapeBuilder {
                     break;
                 case 'arc':
                     const arcAdj = shapeProps.geometry.adjustments;
-                    const arcStartAngle = (arcAdj?.adj1 !== undefined ? arcAdj.adj1 : 10800000) / 60000;
+                    const arcStartAngle = (arcAdj?.adj1 !== undefined ? arcAdj.adj1 : 90) / 60000;
                     const arcSweepAngle = (arcAdj?.adj2 !== undefined ? arcAdj.adj2 : 5400000) / 60000;
                     const arcEndAngle = arcStartAngle + arcSweepAngle;
-
-                    if (shapeName === 'Arc 21') {
-                        console.log(`[DEBUG] Arc Start Angle: ${arcStartAngle}`);
-                        console.log(`[DEBUG] Arc Sweep Angle: ${arcSweepAngle}`);
-                    }
 
                     const arcCenterX = pos.width / 2;
                     const arcCenterY = pos.height / 2;
                     const arcRadiusX = pos.width / 2;
                     const arcRadiusY = pos.height / 2;
 
-                    const arcStart = this.polarToCartesian(arcCenterX, arcCenterY, arcRadiusX, arcRadiusY, arcStartAngle);
-                    const arcEnd = this.polarToCartesian(arcCenterX, arcCenterY, arcRadiusX, arcRadiusY, arcEndAngle);
+                    const arcStart = this.polarToCartesianForArc(arcCenterX, arcCenterY, arcRadiusX, arcRadiusY, arcStartAngle);
+                    const arcEnd = this.polarToCartesianForArc(arcCenterX, arcCenterY, arcRadiusX, arcRadiusY, arcEndAngle);
 
                     const arcLargeArcFlag = arcSweepAngle <= 180 ? "0" : "1";
 
                     const arcPath = [
                         "M", arcStart.x, arcStart.y,
-                        "A", arcRadiusX, arcRadiusY, 0, arcLargeArcFlag, 0, arcEnd.x, arcEnd.y,
+                        "A", arcRadiusX, arcRadiusY, 0, arcLargeArcFlag, 1, arcEnd.x, arcEnd.y,
                     ].join(" ");
-
-                    if (shapeName === 'Arc 21') {
-                        console.log(`[DEBUG] Arc Path: ${arcPath}`);
-                    }
 
                     this.renderer.drawPath(arcPath, {
                         stroke: shapeProps.stroke,
@@ -339,6 +323,14 @@ export class ShapeBuilder {
 
     polarToCartesian(centerX, centerY, radiusX, radiusY, angleInDegrees) {
         const angleInRadians = (angleInDegrees - 180) * Math.PI / 180.0;
+        return {
+            x: centerX + (radiusX * Math.cos(angleInRadians)),
+            y: centerY + (radiusY * Math.sin(angleInRadians))
+        };
+    }
+
+    polarToCartesianForArc(centerX, centerY, radiusX, radiusY, angleInDegrees) {
+        const angleInRadians = angleInDegrees * Math.PI / 180.0;
         return {
             x: centerX + (radiusX * Math.cos(angleInRadians)),
             y: centerY + (radiusY * Math.sin(angleInRadians))

--- a/src/utils/shape-builder.js
+++ b/src/utils/shape-builder.js
@@ -328,4 +328,12 @@ export class ShapeBuilder {
             y: centerY + (radiusY * Math.sin(angleInRadians))
         };
     }
+
+    polarToCartesianForArc(centerX, centerY, radiusX, radiusY, angleInDegrees) {
+        const angleInRadians = angleInDegrees * Math.PI / 180.0;
+        return {
+            x: centerX + (radiusX * Math.cos(angleInRadians)),
+            y: centerY + (radiusY * Math.sin(angleInRadians))
+        };
+    }
 }

--- a/src/utils/shape-builder.js
+++ b/src/utils/shape-builder.js
@@ -39,12 +39,6 @@ export class ShapeBuilder {
         }
 
         const isConnector = shapeName.startsWith('Straight Connector');
-        if (isConnector) {
-            console.log(`[CONNECTOR DEBUG] Processing shape: "${shapeName}"`);
-            console.log('[CONNECTOR DEBUG] Parent Matrix:', parentMatrix.m);
-        } else {
-            console.log(`[DEBUG] Processing shape: "${shapeName}", phKey: ${phKey}, phType: ${phType}`);
-        }
 
         let localMatrix = new Matrix();
         let pos;
@@ -105,14 +99,17 @@ export class ShapeBuilder {
 
         const finalMatrix = parentMatrix.clone().multiply(localMatrix);
 
-        if (isConnector) {
-            console.log('[CONNECTOR DEBUG] Local Matrix:', localMatrix.m);
-            console.log('[CONNECTOR DEBUG] Final Matrix:', finalMatrix.m);
-        }
 
         this.renderer.setTransform(finalMatrix);
 
         const txBody = shapeNode.getElementsByTagNameNS(PML_NS, 'txBody')[0];
+
+        if (shapeName === 'Straight Connector 11' || shapeName === 'Arc 21') {
+            console.log(`[DEBUG] Shape: ${shapeName}`);
+            console.log(`[DEBUG] Position:`, JSON.stringify(pos, null, 2));
+            console.log(`[DEBUG] Final Matrix:`, finalMatrix.m);
+            console.log(`[DEBUG] Stroke Properties:`, JSON.stringify(shapeProps.stroke, null, 2));
+        }
 
         if (shapeProps && shapeProps.geometry) {
              const geomType = shapeProps.geometry.type === 'preset' ? shapeProps.geometry.preset : shapeProps.geometry.type;
@@ -155,6 +152,11 @@ export class ShapeBuilder {
                     const arcSweepAngle = (arcAdj?.adj2 !== undefined ? arcAdj.adj2 : 5400000) / 60000;
                     const arcEndAngle = arcStartAngle + arcSweepAngle;
 
+                    if (shapeName === 'Arc 21') {
+                        console.log(`[DEBUG] Arc Start Angle: ${arcStartAngle}`);
+                        console.log(`[DEBUG] Arc Sweep Angle: ${arcSweepAngle}`);
+                    }
+
                     const arcCenterX = pos.width / 2;
                     const arcCenterY = pos.height / 2;
                     const arcRadiusX = pos.width / 2;
@@ -169,6 +171,10 @@ export class ShapeBuilder {
                         "M", arcStart.x, arcStart.y,
                         "A", arcRadiusX, arcRadiusY, 0, arcLargeArcFlag, 1, arcEnd.x, arcEnd.y,
                     ].join(" ");
+
+                    if (shapeName === 'Arc 21') {
+                        console.log(`[DEBUG] Arc Path: ${arcPath}`);
+                    }
 
                     this.renderer.drawPath(arcPath, {
                         stroke: shapeProps.stroke,

--- a/src/utils/shape-builder.js
+++ b/src/utils/shape-builder.js
@@ -104,6 +104,13 @@ export class ShapeBuilder {
 
         const txBody = shapeNode.getElementsByTagNameNS(PML_NS, 'txBody')[0];
 
+        if (shapeName === 'Straight Connector 11' || shapeName === 'Arc 21') {
+            console.log(`[DEBUG] Shape: ${shapeName}`);
+            console.log(`[DEBUG] Position:`, JSON.stringify(pos, null, 2));
+            console.log(`[DEBUG] Final Matrix:`, finalMatrix.m);
+            console.log(`[DEBUG] Stroke Properties:`, JSON.stringify(shapeProps.stroke, null, 2));
+        }
+
         if (shapeProps && shapeProps.geometry) {
              const geomType = shapeProps.geometry.type === 'preset' ? shapeProps.geometry.preset : shapeProps.geometry.type;
              switch (geomType) {
@@ -145,6 +152,11 @@ export class ShapeBuilder {
                     const arcSweepAngle = (arcAdj?.adj2 !== undefined ? arcAdj.adj2 : 5400000) / 60000;
                     const arcEndAngle = arcStartAngle + arcSweepAngle;
 
+                    if (shapeName === 'Arc 21') {
+                        console.log(`[DEBUG] Arc Start Angle: ${arcStartAngle}`);
+                        console.log(`[DEBUG] Arc Sweep Angle: ${arcSweepAngle}`);
+                    }
+
                     const arcCenterX = pos.width / 2;
                     const arcCenterY = pos.height / 2;
                     const arcRadiusX = pos.width / 2;
@@ -157,8 +169,12 @@ export class ShapeBuilder {
 
                     const arcPath = [
                         "M", arcStart.x, arcStart.y,
-                        "A", arcRadiusX, arcRadiusY, 0, arcLargeArcFlag, 1, arcEnd.x, arcEnd.y,
+                        "A", arcRadiusX, arcRadiusY, 0, arcLargeArcFlag, 0, arcEnd.x, arcEnd.y,
                     ].join(" ");
+
+                    if (shapeName === 'Arc 21') {
+                        console.log(`[DEBUG] Arc Path: ${arcPath}`);
+                    }
 
                     this.renderer.drawPath(arcPath, {
                         stroke: shapeProps.stroke,


### PR DESCRIPTION
Fix rendering of line caps, dash patterns, and arcs

This commit addresses three issues:
1. The `cap` attribute from OOXML was not correctly mapped to the HTML5 canvas `lineCap` property. For example, "rnd" was used instead of "round".
2. The preset dash patterns (`prstDash`) were implemented with hardcoded pixel values, which did not scale with the line width as specified in the OOXML standard.
3. The `arc` preset shape was rendered with an incorrect orientation due to a combination of incorrect default angles and a non-standard polar-to-cartesian conversion.

This commit addresses these issues by:
- Mapping OOXML line cap values to their corresponding canvas values in `parseLineProperties`.
- Calculating dash patterns based on line width and the OOXML specification in `parseLineProperties`.
- Adding a new `polarToCartesianForArc` helper function that uses standard angle conversion and accounts for the Y-down coordinate system.
- Updating the `arc` rendering logic to use the new helper function with correct default angles (90 degrees start, 90 degrees sweep) to produce a top-left arc.
- Updating `parseShapeProperties` in `index.html` to parse adjustment values for all preset geometries.