### PR TITLE
Feature/gradient fills

### DIFF
--- a/index.html
+++ b/index.html
@@ -2772,17 +2772,11 @@
                     bgRect.setAttribute('fill', finalBg.value);
                     svg.insertBefore(bgRect, svg.firstChild);
                 } else if (finalBg.type === 'gradient') {
-                    // Create a rect that fills the entire slide, and use the renderer to apply the gradient
                     const bgRect = document.createElementNS(SVG_NS, 'rect');
                     bgRect.setAttribute('width', '100%');
                     bgRect.setAttribute('height', '100%');
-
-                    // The renderer will create the gradient in defs and apply it
-                    const fill = renderer.drawRect(0, 0, slideSize.width, slideSize.height, { fill: finalBg });
-
-                    // The drawRect function will append its own rect, so we just need to apply the fill to our background rect.
-                    // We will handle the actual drawing of the gradient within the SvgRenderer itself.
-                    // For now, let's ensure the background rect is added.
+                    const gradientUrl = renderer._createGradient(finalBg);
+                    bgRect.setAttribute('fill', gradientUrl);
                     svg.insertBefore(bgRect, svg.firstChild);
                 } else if (finalBg.type === 'image' && finalBg.relId && imageMap[finalBg.relId]) {
                     const bgImage = document.createElementNS(SVG_NS, 'image');

--- a/index.html
+++ b/index.html
@@ -1068,7 +1068,7 @@
             return null;
         }
 
-        function resolveColor(colorObj, slideContext) {
+        function resolveColor(colorObj, slideContext, returnObject = false) {
             if (!colorObj || !slideContext.theme) {
                 return null;
             }
@@ -1092,10 +1092,15 @@
             }
 
             if (hex) {
-                if (colorObj.alpha) {
+                const alpha = colorObj.alpha !== undefined ? colorObj.alpha / 100000 : 1.0;
+                if (returnObject) {
+                    return { color: hex, alpha: alpha };
+                }
+
+                if (alpha < 1.0) {
                     const rgb = hexToRgb(hex);
                     if (rgb) {
-                        return `rgba(${rgb.r}, ${rgb.g}, ${rgb.b}, ${colorObj.alpha / 100000})`;
+                        return `rgba(${rgb.r}, ${rgb.g}, ${rgb.b}, ${alpha})`;
                     }
                 }
                 return hex;
@@ -1223,6 +1228,11 @@
                     }
                 }
 
+                const gradFillNode = bgPrNode.getElementsByTagNameNS(DML_NS, 'gradFill')[0];
+                if (gradFillNode) {
+                    return parseGradientFill(gradFillNode, slideContext);
+                }
+
                 const blipFillNode = bgPrNode.getElementsByTagNameNS(DML_NS, 'blipFill')[0];
                 if (blipFillNode) {
                     const blipNode = blipFillNode.getElementsByTagNameNS(DML_NS, 'blip')[0];
@@ -1271,6 +1281,35 @@
                 w: pathW,
                 h: pathH,
             };
+        }
+
+        function parseGradientFill(fillNode, slideContext) {
+            const DML_NS = "http://schemas.openxmlformats.org/drawingml/2006/main";
+            const gsLstNode = fillNode.getElementsByTagNameNS(DML_NS, 'gsLst')[0];
+            const stops = [];
+            if (gsLstNode) {
+                for (const gsNode of gsLstNode.children) {
+                    const pos = parseInt(gsNode.getAttribute('pos')) / 100000;
+                    const colorObj = parseColor(gsNode);
+                    if (colorObj) {
+                        stops.push({ pos, color: resolveColor(colorObj, slideContext, true) });
+                    }
+                }
+            }
+
+            let angle = 0;
+            let type = 'linear';
+            const linNode = fillNode.getElementsByTagNameNS(DML_NS, 'lin')[0];
+            if (linNode) {
+                angle = parseInt(linNode.getAttribute('ang')) / 60000;
+            }
+
+            const pathNode = fillNode.getElementsByTagNameNS(DML_NS, 'path')[0];
+            if(pathNode) {
+                type = 'path';
+            }
+
+            return { type: 'gradient', gradient: { type, stops, angle } };
         }
 
         function parseLineProperties(lnNode, slideContext) {
@@ -1406,7 +1445,7 @@
                     const colorObj = parseColor(fillNode);
                     if (colorObj) properties.fill = { type: 'solid', color: resolveColor(colorObj, slideContext) };
                 } else if (fillNode.localName === 'gradFill') {
-                    // Gradient parsing logic...
+                    properties.fill = parseGradientFill(fillNode, slideContext);
                 }
             } else {
                 const styleNode = shapeNode.getElementsByTagNameNS(PML_NS, 'style')[0];
@@ -2731,6 +2770,19 @@
                     bgRect.setAttribute('width', '100%');
                     bgRect.setAttribute('height', '100%');
                     bgRect.setAttribute('fill', finalBg.value);
+                    svg.insertBefore(bgRect, svg.firstChild);
+                } else if (finalBg.type === 'gradient') {
+                    // Create a rect that fills the entire slide, and use the renderer to apply the gradient
+                    const bgRect = document.createElementNS(SVG_NS, 'rect');
+                    bgRect.setAttribute('width', '100%');
+                    bgRect.setAttribute('height', '100%');
+
+                    // The renderer will create the gradient in defs and apply it
+                    const fill = renderer.drawRect(0, 0, slideSize.width, slideSize.height, { fill: finalBg });
+
+                    // The drawRect function will append its own rect, so we just need to apply the fill to our background rect.
+                    // We will handle the actual drawing of the gradient within the SvgRenderer itself.
+                    // For now, let's ensure the background rect is added.
                     svg.insertBefore(bgRect, svg.firstChild);
                 } else if (finalBg.type === 'image' && finalBg.relId && imageMap[finalBg.relId]) {
                     const bgImage = document.createElementNS(SVG_NS, 'image');

--- a/index.html
+++ b/index.html
@@ -2255,13 +2255,12 @@
             // Level 1: Direct Formatting (highest precedence)
             const tcPrNode = cellNode.getElementsByTagNameNS(DML_NS, 'tcPr')[0];
             if (tcPrNode) {
-                let solidFillNode = null;
-                for (const child of tcPrNode.children) {
-                    if (child.localName === 'solidFill') {
-                        solidFillNode = child;
-                        break;
-                    }
+                const gradFillNode = tcPrNode.getElementsByTagNameNS(DML_NS, 'gradFill')[0];
+                if (gradFillNode) {
+                    return parseGradientFill(gradFillNode, slideContext);
                 }
+
+                const solidFillNode = tcPrNode.getElementsByTagNameNS(DML_NS, 'solidFill')[0];
                 if (solidFillNode) {
                     const colorObj = parseColor(solidFillNode);
                     if (colorObj) {

--- a/index.html
+++ b/index.html
@@ -2284,15 +2284,30 @@
             // Level 1: Direct Formatting (highest precedence)
             const tcPrNode = cellNode.getElementsByTagNameNS(DML_NS, 'tcPr')[0];
             if (tcPrNode) {
-                const noFillNode = tcPrNode.getElementsByTagNameNS(DML_NS, 'noFill')[0];
-                if (noFillNode) return 'none';
+                for ( const child of tcPrNode.children ) {
+                    if ( child.localName === 'noFill' ) {
+                        return 'none';
+                    }
+                }
 
-                const gradFillNode = tcPrNode.getElementsByTagNameNS(DML_NS, 'gradFill')[0];
+                let gradFillNode = null;
+                for ( const child of tcPrNode.children ) {
+                    if ( child.localName === 'gradFill' ) {
+                        gradFillNode = child;
+                        break;
+                    }
+                }
                 if (gradFillNode) {
                     return parseGradientFill(gradFillNode, slideContext);
                 }
 
-                const solidFillNode = tcPrNode.getElementsByTagNameNS(DML_NS, 'solidFill')[0];
+                let solidFillNode = null;
+                for ( const child of tcPrNode.children ) {
+                    if ( child.localName === 'solidFill' ) {
+                        solidFillNode = child;
+                        break;
+                    }
+                }
                 if (solidFillNode) {
                     const colorObj = parseColor(solidFillNode);
                     if (colorObj) {

--- a/index.html
+++ b/index.html
@@ -774,7 +774,7 @@
                             const stops = [];
                             if (gsLstNode) {
                                 for (const gsNode of gsLstNode.children) {
-                                    const pos = parseInt(gsNode.getAttribute('pos')) / 1000; // Position is in 1000ths of a percent
+                                    const pos = parseInt(gsNode.getAttribute('pos')) / 100000;
                                     const colorObj = parseColor(gsNode);
                                     if (colorObj) {
                                         stops.push({ pos, color: colorObj });
@@ -782,11 +782,16 @@
                                 }
                             }
                             let angle = 0;
+                            let type = 'linear';
                             const linNode = fillNode.getElementsByTagNameNS(DML_NS, 'lin')[0];
                             if (linNode) {
-                                angle = parseInt(linNode.getAttribute('ang')) / 60000; // Angle is in 60000ths of a degree
+                                angle = parseInt(linNode.getAttribute('ang')) / 60000;
                             }
-                            theme.formatScheme.fills.push({ type: 'gradient', stops, angle });
+                            const pathNode = fillNode.getElementsByTagNameNS(DML_NS, 'path')[0];
+                            if(pathNode) {
+                                type = 'path';
+                            }
+                            theme.formatScheme.fills.push({ type: 'gradient', gradient: { type, stops, angle } });
                         } else if (fillNode.localName === 'blipFill') {
                             const blipNode = fillNode.getElementsByTagNameNS(DML_NS, 'blip')[0];
                             if (blipNode) {
@@ -877,7 +882,7 @@
                             const stops = [];
                             if (gsLstNode) {
                                 for (const gsNode of gsLstNode.children) {
-                                    const pos = parseInt(gsNode.getAttribute('pos')) / 1000; // Position is in 1000ths of a percent
+                                    const pos = parseInt(gsNode.getAttribute('pos')) / 100000;
                                     const colorObj = parseColor(gsNode);
                                     if (colorObj) {
                                         stops.push({ pos, color: colorObj });
@@ -885,11 +890,16 @@
                                 }
                             }
                             let angle = 0;
+                            let type = 'linear';
                             const linNode = fillNode.getElementsByTagNameNS(DML_NS, 'lin')[0];
                             if (linNode) {
-                                angle = parseInt(linNode.getAttribute('ang')) / 60000; // Angle is in 60000ths of a degree
+                                angle = parseInt(linNode.getAttribute('ang')) / 60000;
                             }
-                            theme.formatScheme.bgFills.push({ type: 'gradient', stops, angle });
+                            const pathNode = fillNode.getElementsByTagNameNS(DML_NS, 'path')[0];
+                            if(pathNode) {
+                                type = 'path';
+                            }
+                            theme.formatScheme.bgFills.push({ type: 'gradient', gradient: { type, stops, angle } });
                         } else if (fillNode.localName === 'blipFill') {
                             const blipNode = fillNode.getElementsByTagNameNS(DML_NS, 'blip')[0];
                             if (blipNode) {
@@ -1065,6 +1075,33 @@
                 return color;
             }
 
+            const bgRefNode = bgNode.getElementsByTagNameNS(PML_NS, 'bgRef')[0];
+            if (bgRefNode) {
+                const idx = parseInt(bgRefNode.getAttribute('idx'));
+                if (idx > 0 && idx < 1000) { // 1-based index for bgFillStyleLst
+                    const themeBgFill = slideContext.theme.formatScheme.bgFills[idx - 1];
+                    if (themeBgFill) {
+                        if (themeBgFill.type === 'solid') {
+                            const color = resolveColor(themeBgFill.color, slideContext);
+                            bg = { type: 'color', value: color };
+                        } else if (themeBgFill.type === 'gradient') {
+                             // Here we need to resolve the colors in the stops
+                            const resolvedStops = themeBgFill.gradient.stops.map(stop => ({
+                                ...stop,
+                                color: resolveColor(stop.color, slideContext, true)
+                            }));
+                            bg = { type: 'gradient', gradient: { ...themeBgFill.gradient, stops: resolvedStops } };
+                        }
+                    }
+                } else if (idx >= 1000) {
+                    const colorObj = parseColor(bgRefNode);
+                    if (colorObj) {
+                        bg = { type: 'color', value: resolveColor(colorObj, slideContext) };
+                    }
+                }
+            }
+
+            console.log("[DEBUG] Parsed background: null");
             return null;
         }
 
@@ -1218,19 +1255,22 @@
             const bgNode = xmlDoc.getElementsByTagNameNS(PML_NS, 'bg')[0];
             if (!bgNode) return null;
 
+            console.log("[DEBUG] Parsing background for:", xmlDoc.firstElementChild.localName);
+
+            let bg = null;
             const bgPrNode = bgNode.getElementsByTagNameNS(PML_NS, 'bgPr')[0];
             if (bgPrNode) {
                 const solidFillNode = bgPrNode.getElementsByTagNameNS(DML_NS, 'solidFill')[0];
                 if (solidFillNode) {
                     const colorObj = parseColor(solidFillNode);
                     if (colorObj) {
-                        return { type: 'color', value: resolveColor(colorObj, slideContext) };
+                        bg = { type: 'color', value: resolveColor(colorObj, slideContext) };
                     }
                 }
 
                 const gradFillNode = bgPrNode.getElementsByTagNameNS(DML_NS, 'gradFill')[0];
                 if (gradFillNode) {
-                    return parseGradientFill(gradFillNode, slideContext);
+                    bg = parseGradientFill(gradFillNode, slideContext);
                 }
 
                 const blipFillNode = bgPrNode.getElementsByTagNameNS(DML_NS, 'blipFill')[0];
@@ -1284,6 +1324,7 @@
         }
 
         function parseGradientFill(fillNode, slideContext) {
+            console.log("[DEBUG] Parsing gradient fill:", fillNode.outerHTML);
             const DML_NS = "http://schemas.openxmlformats.org/drawingml/2006/main";
             const gsLstNode = fillNode.getElementsByTagNameNS(DML_NS, 'gsLst')[0];
             const stops = [];
@@ -1309,7 +1350,9 @@
                 type = 'path';
             }
 
-            return { type: 'gradient', gradient: { type, stops, angle } };
+            const result = { type: 'gradient', gradient: { type, stops, angle } };
+            console.log("[DEBUG] Parsed gradient fill:", JSON.stringify(result, null, 2));
+            return result;
         }
 
         function parseLineProperties(lnNode, slideContext) {
@@ -1543,6 +1586,12 @@
                     }
                  }
             }
+
+            console.log(`[DEBUG] Parsed shape properties for shape on slide ${slideNum}:`, {
+                fill: properties.fill,
+                stroke: properties.stroke,
+                geometry: properties.geometry
+            });
             return properties;
         }
 

--- a/index.html
+++ b/index.html
@@ -1075,33 +1075,6 @@
                 return color;
             }
 
-            const bgRefNode = bgNode.getElementsByTagNameNS(PML_NS, 'bgRef')[0];
-            if (bgRefNode) {
-                const idx = parseInt(bgRefNode.getAttribute('idx'));
-                if (idx > 0 && idx < 1000) { // 1-based index for bgFillStyleLst
-                    const themeBgFill = slideContext.theme.formatScheme.bgFills[idx - 1];
-                    if (themeBgFill) {
-                        if (themeBgFill.type === 'solid') {
-                            const color = resolveColor(themeBgFill.color, slideContext);
-                            bg = { type: 'color', value: color };
-                        } else if (themeBgFill.type === 'gradient') {
-                             // Here we need to resolve the colors in the stops
-                            const resolvedStops = themeBgFill.gradient.stops.map(stop => ({
-                                ...stop,
-                                color: resolveColor(stop.color, slideContext, true)
-                            }));
-                            bg = { type: 'gradient', gradient: { ...themeBgFill.gradient, stops: resolvedStops } };
-                        }
-                    }
-                } else if (idx >= 1000) {
-                    const colorObj = parseColor(bgRefNode);
-                    if (colorObj) {
-                        bg = { type: 'color', value: resolveColor(colorObj, slideContext) };
-                    }
-                }
-            }
-
-            console.log("[DEBUG] Parsed background: null");
             return null;
         }
 

--- a/index.html
+++ b/index.html
@@ -1253,12 +1253,16 @@
             const DML_NS = "http://schemas.openxmlformats.org/drawingml/2006/main";
 
             const bgNode = xmlDoc.getElementsByTagNameNS(PML_NS, 'bg')[0];
-            if (!bgNode) return null;
+            if (!bgNode) {
+                return null;
+            }
 
             console.log("[DEBUG] Parsing background for:", xmlDoc.firstElementChild.localName);
 
             let bg = null;
             const bgPrNode = bgNode.getElementsByTagNameNS(PML_NS, 'bgPr')[0];
+            const bgRefNode = bgNode.getElementsByTagNameNS(PML_NS, 'bgRef')[0];
+
             if (bgPrNode) {
                 const solidFillNode = bgPrNode.getElementsByTagNameNS(DML_NS, 'solidFill')[0];
                 if (solidFillNode) {
@@ -1278,12 +1282,35 @@
                     const blipNode = blipFillNode.getElementsByTagNameNS(DML_NS, 'blip')[0];
                     if (blipNode) {
                         const relId = blipNode.getAttribute('r:embed');
-                        return { type: 'image', relId: relId };
+                        bg = { type: 'image', relId: relId };
+                    }
+                }
+            } else if (bgRefNode) {
+                const idx = parseInt(bgRefNode.getAttribute('idx'));
+                if (idx > 0 && idx < 1000) {
+                    const themeBgFill = slideContext.theme.formatScheme.bgFills[idx - 1];
+                    if (themeBgFill) {
+                        if (themeBgFill.type === 'solid') {
+                            const color = resolveColor(themeBgFill.color, slideContext);
+                            bg = { type: 'color', value: color };
+                        } else if (themeBgFill.type === 'gradient') {
+                            const resolvedStops = themeBgFill.gradient.stops.map(stop => ({
+                                ...stop,
+                                color: resolveColor(stop.color, slideContext, true)
+                            }));
+                            bg = { type: 'gradient', gradient: { ...themeBgFill.gradient, stops: resolvedStops } };
+                        }
+                    }
+                } else if (idx >= 1000) {
+                    const colorObj = parseColor(bgRefNode);
+                    if (colorObj) {
+                        bg = { type: 'color', value: resolveColor(colorObj, slideContext) };
                     }
                 }
             }
 
-            return null;
+            console.log(`[DEBUG] Parsed background for ${xmlDoc.firstElementChild.localName}:`, JSON.stringify(bg, null, 2));
+            return bg;
         }
 
         function parseCustomGeometry(custGeomNode) {

--- a/index.html
+++ b/index.html
@@ -1156,11 +1156,31 @@
 
             const tcStyleNode = partNode.getElementsByTagNameNS(DML_NS, 'tcStyle')[0];
             if (tcStyleNode) {
-                const fillNode = tcStyleNode.getElementsByTagNameNS(DML_NS, 'fill')[0];
-                if (fillNode) {
-                    const solidFillNode = fillNode.getElementsByTagNameNS(DML_NS, 'solidFill')[0];
-                    if (solidFillNode) {
-                        partDef.tcStyle.fill = parseColor(solidFillNode);
+                const fillChild = tcStyleNode.getElementsByTagNameNS(DML_NS, 'fill')[0]?.children[0];
+                if (fillChild) {
+                    if (fillChild.localName === 'noFill') {
+                        partDef.tcStyle.fill = { type: 'none' };
+                    } else if (fillChild.localName === 'solidFill') {
+                        partDef.tcStyle.fill = { type: 'solid', color: parseColor(fillChild) };
+                    } else if (fillChild.localName === 'gradFill') {
+                        const gsLstNode = fillChild.getElementsByTagNameNS(DML_NS, 'gsLst')[0];
+                        const stops = [];
+                        if (gsLstNode) {
+                            for (const gsNode of gsLstNode.children) {
+                                const pos = parseInt(gsNode.getAttribute('pos')) / 100000;
+                                const colorObj = parseColor(gsNode);
+                                if (colorObj) {
+                                    stops.push({ pos, color: colorObj });
+                                }
+                            }
+                        }
+                        let angle = 0;
+                        let type = 'linear';
+                        const linNode = fillChild.getElementsByTagNameNS(DML_NS, 'lin')[0];
+                        if (linNode) {
+                            angle = parseInt(linNode.getAttribute('ang')) / 60000;
+                        }
+                        partDef.tcStyle.fill = { type: 'gradient', gradient: { type, stops, angle } };
                     }
                 }
 
@@ -2255,6 +2275,9 @@
             // Level 1: Direct Formatting (highest precedence)
             const tcPrNode = cellNode.getElementsByTagNameNS(DML_NS, 'tcPr')[0];
             if (tcPrNode) {
+                const noFillNode = tcPrNode.getElementsByTagNameNS(DML_NS, 'noFill')[0];
+                if (noFillNode) return 'none';
+
                 const gradFillNode = tcPrNode.getElementsByTagNameNS(DML_NS, 'gradFill')[0];
                 if (gradFillNode) {
                     return parseGradientFill(gradFillNode, slideContext);
@@ -2264,16 +2287,14 @@
                 if (solidFillNode) {
                     const colorObj = parseColor(solidFillNode);
                     if (colorObj) {
-                        return resolveColor(colorObj, slideContext);
+                        return { type: 'solid', color: resolveColor(colorObj, slideContext) };
                     }
                 }
             }
 
-            if (!tableStyle) {
-                return null;
-            }
+            // Level 2 & 3: Table Styles
+            if (!tableStyle) return null;
 
-            // Level 2 & 3: Table Styles (layered)
             let finalFill = null;
 
             // Base fill from wholeTbl
@@ -2330,7 +2351,23 @@
                 }
             }
 
-            return finalFill ? resolveColor(finalFill, slideContext) : null;
+            if (finalFill) {
+                if (finalFill.type === 'none') {
+                    return 'none';
+                }
+                if (finalFill.type === 'solid') {
+                    return { type: 'solid', color: resolveColor(finalFill.color, slideContext) };
+                }
+                if (finalFill.type === 'gradient') {
+                    const resolvedStops = finalFill.gradient.stops.map(stop => ({
+                        ...stop,
+                        color: resolveColor(stop.color, slideContext, true)
+                    }));
+                    return { type: 'gradient', gradient: { ...finalFill.gradient, stops: resolvedStops } };
+                }
+            }
+
+            return null;
         }
 
         async function processTable(graphicFrame, renderer, slideContext, parentMatrix) {

--- a/index.html
+++ b/index.html
@@ -496,7 +496,7 @@
             return theme?.fontScheme?.minor || 'Arial';
         }
 
-        function layoutParagraphs(paragraphs, pos, defaultTextStyles, phKey, phType, masterPlaceholders, layoutPlaceholders, slideContext, bodyPr) {
+        function layoutParagraphs(paragraphs, pos, defaultTextStyles, phKey, phType, masterPlaceholders, layoutPlaceholders, slideContext, bodyPr, tableTextStyle = {}) {
             const DML_NS = "http://schemas.openxmlformats.org/drawingml/2006/main";
 
             const paddedPos = {
@@ -538,7 +538,7 @@
                     ...layoutListStyle,
                     ...slideLevelProps,
                     bullet: { ...defaultLevelProps.bullet, ...masterListStyle.bullet, ...layoutListStyle.bullet, ...slideLevelProps.bullet },
-                    defRPr: { ...defaultLevelProps.defRPr, ...masterListStyle.defRPr, ...layoutListStyle.defRPr, ...slideLevelProps.defRPr }
+                    defRPr: { ...defaultLevelProps.defRPr, ...masterListStyle.defRPr, ...layoutListStyle.defRPr, ...slideLevelProps.defRPr, ...tableTextStyle }
                 };
 
                 const marL = (finalProps.marL !== undefined) ? finalProps.marL : (level > 0 ? (level * INDENTATION_AMOUNT) : 0);
@@ -1156,12 +1156,14 @@
 
             const tcStyleNode = partNode.getElementsByTagNameNS(DML_NS, 'tcStyle')[0];
             if (tcStyleNode) {
-                const fillChild = tcStyleNode.getElementsByTagNameNS(DML_NS, 'fill')[0]?.children[0];
-                if (fillChild) {
+                const fillContainer = tcStyleNode.getElementsByTagNameNS(DML_NS, 'fill')[0] || tcStyleNode;
+                for (const fillChild of fillContainer.children) {
                     if (fillChild.localName === 'noFill') {
                         partDef.tcStyle.fill = { type: 'none' };
+                        break;
                     } else if (fillChild.localName === 'solidFill') {
                         partDef.tcStyle.fill = { type: 'solid', color: parseColor(fillChild) };
+                        break;
                     } else if (fillChild.localName === 'gradFill') {
                         const gsLstNode = fillChild.getElementsByTagNameNS(DML_NS, 'gsLst')[0];
                         const stops = [];
@@ -1181,6 +1183,7 @@
                             angle = parseInt(linNode.getAttribute('ang')) / 60000;
                         }
                         partDef.tcStyle.fill = { type: 'gradient', gradient: { type, stops, angle } };
+                        break;
                     }
                 }
 
@@ -1228,10 +1231,16 @@
                 }
 
                 // Color can be in fontRef or a direct child of tcTxStyle
-                const fontRefNode = tcTxStyleNode.getElementsByTagNameNS( DML_NS, 'fontRef' )[ 0 ];
-                const colorSourceNode = fontRefNode || tcTxStyleNode;
-                const colorObj = parseColor( colorSourceNode );
-                if ( colorObj ) {
+                const fontRefNode = tcTxStyleNode.getElementsByTagNameNS(DML_NS, 'fontRef')[0];
+                const colorContainerNode = fontRefNode || tcTxStyleNode; // This is where the color info lives
+
+                // The actual color can be a direct child, or inside a fill tag.
+                const solidFillNode = colorContainerNode.getElementsByTagNameNS(DML_NS, 'solidFill')[0];
+
+                const colorSourceNode = solidFillNode || colorContainerNode; // Pass the fill node if it exists
+
+                const colorObj = parseColor(colorSourceNode);
+                if (colorObj) {
                     style.color = colorObj;
                 }
 
@@ -2370,6 +2379,69 @@
             return null;
         }
 
+        function getCellTextStyle(tblPrNode, r, c, numRows, numCols, tableStyle) {
+            if (!tableStyle) return {};
+
+            let finalStyle = {};
+
+            // Base style from wholeTbl
+            if (tableStyle.wholeTbl && tableStyle.wholeTbl.tcTxStyle) {
+                finalStyle = { ...tableStyle.wholeTbl.tcTxStyle };
+            }
+
+            const firstRow = tblPrNode.getAttribute('firstRow') === '1';
+            const lastRow = tblPrNode.getAttribute('lastRow') === '1';
+            const firstCol = tblPrNode.getAttribute('firstCol') === '1';
+            const lastCol = tblPrNode.getAttribute('lastCol') === '1';
+            const bandRow = tblPrNode.getAttribute('bandRow') === '1';
+            const bandCol = tblPrNode.getAttribute('bandCol') === '1';
+
+            const isFirstRow = r === 0;
+            const isLastRow = r === numRows - 1;
+            const isFirstCol = c === 0;
+            const isLastCol = c === numCols - 1;
+
+            // Layer styles in increasing order of precedence
+            const partsToCheck = [];
+            if (bandRow) {
+                const isDataRow = !(firstRow && isFirstRow) && !(lastRow && isLastRow);
+                if (isDataRow) {
+                    const dataRowIdx = firstRow ? r - 1 : r;
+                    if (dataRowIdx >= 0) {
+                        if (dataRowIdx % 2 === 0 && tableStyle.band1H) { partsToCheck.push(tableStyle.band1H); }
+                        else if (dataRowIdx % 2 === 1 && tableStyle.band2H) { partsToCheck.push(tableStyle.band2H); }
+                    }
+                }
+            }
+            if (bandCol) {
+                const isDataCol = !(firstCol && isFirstCol) && !(lastCol && isLastCol);
+                if (isDataCol) {
+                    const dataColIdx = firstCol ? c - 1 : c;
+                    if (dataColIdx >= 0) {
+                        if (dataColIdx % 2 === 0 && tableStyle.band1V) { partsToCheck.push(tableStyle.band1V); }
+                        else if (dataColIdx % 2 === 1 && tableStyle.band2V) { partsToCheck.push(tableStyle.band2V); }
+                    }
+                }
+            }
+            if (firstRow && isFirstRow && tableStyle.firstRow) { partsToCheck.push(tableStyle.firstRow); }
+            if (lastRow && isLastRow && tableStyle.lastRow) { partsToCheck.push(tableStyle.lastRow); }
+            if (firstCol && isFirstCol && tableStyle.firstCol) { partsToCheck.push(tableStyle.firstCol); }
+            if (lastCol && isLastCol && tableStyle.lastCol) { partsToCheck.push(tableStyle.lastCol); }
+            if (firstRow && isFirstRow && firstCol && isFirstCol && tableStyle.nwCell) { partsToCheck.push(tableStyle.nwCell); }
+            if (firstRow && isFirstRow && lastCol && isLastCol && tableStyle.neCell) { partsToCheck.push(tableStyle.neCell); }
+            if (lastRow && isLastRow && firstCol && isFirstCol && tableStyle.swCell) { partsToCheck.push(tableStyle.swCell); }
+            if (lastRow && isLastRow && lastCol && isLastCol && tableStyle.seCell) { partsToCheck.push(tableStyle.seCell); }
+
+
+            for (const part of partsToCheck) {
+                if (part && part.tcTxStyle) {
+                    finalStyle = { ...finalStyle, ...part.tcTxStyle };
+                }
+            }
+
+            return finalStyle;
+        }
+
         async function processTable(graphicFrame, renderer, slideContext, parentMatrix) {
             const DML_NS = "http://schemas.openxmlformats.org/drawingml/2006/main";
             const PML_NS = "http://schemas.openxmlformats.org/presentationml/2006/main";
@@ -2492,6 +2564,7 @@
 
                     // Step 4: Get cell styling
                     const fillColor = getCellFillColor(cellNode, tblPrNode, r, c, numRows, numCols, tableStyle, slideContext);
+                    const textStyle = getCellTextStyle(tblPrNode, r, c, numRows, numCols, tableStyle);
 
                     renderer.drawRect(cellX, cellY, cellWidth, cellHeight, { fill: fillColor || 'transparent' });
 
@@ -2512,7 +2585,7 @@
                     }
 
                     // Render text content
-                    await processCellText(cellNode, renderer, cellX, cellY, cellWidth, cellHeight, slideContext);
+                    await processCellText(cellNode, renderer, cellX, cellY, cellWidth, cellHeight, slideContext, textStyle);
                 }
             }
 
@@ -2522,7 +2595,7 @@
             };
         }
 
-        async function processCellText(cellNode, renderer, cellX, cellY, cellWidth, cellHeight, slideContext) {
+        async function processCellText(cellNode, renderer, cellX, cellY, cellWidth, cellHeight, slideContext, tableTextStyle = {}) {
             const DML_NS = "http://schemas.openxmlformats.org/drawingml/2006/main";
             const txBodyNode = cellNode.getElementsByTagNameNS(DML_NS, 'txBody')[0];
             if (!txBodyNode) return;
@@ -2590,7 +2663,7 @@
             const masterPlaceholders = {};
             const layoutPlaceholders = {};
 
-            await processParagraphs(renderer, txBodyNode, pos, null, 'body', slideContext, {}, listCounters, defaultTextStyles, masterPlaceholders, layoutPlaceholders, bodyPr);
+            await processParagraphs(renderer, txBodyNode, pos, null, 'body', slideContext, {}, listCounters, defaultTextStyles, masterPlaceholders, layoutPlaceholders, bodyPr, tableTextStyle);
 
             renderer.currentGroup = originalGroup;
         }

--- a/src/utils/shape-builder.js
+++ b/src/utils/shape-builder.js
@@ -107,14 +107,14 @@ export class ShapeBuilder {
              switch (geomType) {
                 case 'rect':
                     this.renderer.drawRect(0, 0, pos.width, pos.height, {
-                        fill: shapeProps.fill?.color,
+                        fill: shapeProps.fill,
                         stroke: shapeProps.stroke,
                         effect: shapeProps.effect,
                     });
                     break;
                 case 'ellipse':
                     this.renderer.drawEllipse(pos.width / 2, pos.height / 2, pos.width / 2, pos.height / 2, {
-                        fill: shapeProps.fill?.color,
+                        fill: shapeProps.fill,
                         stroke: shapeProps.stroke,
                         effect: shapeProps.effect,
                     });
@@ -218,7 +218,7 @@ export class ShapeBuilder {
                             }
                         });
                         this.renderer.drawPath(pathString, {
-                            fill: shapeProps.fill?.color,
+                            fill: shapeProps.fill,
                             stroke: shapeProps.stroke,
                             effect: shapeProps.effect,
                         });
@@ -259,7 +259,7 @@ export class ShapeBuilder {
                     ].join(" ");
 
                     this.renderer.drawPath(path, {
-                        fill: shapeProps.fill?.color,
+                        fill: shapeProps.fill,
                         stroke: shapeProps.stroke,
                         effect: shapeProps.effect,
                     });
@@ -283,7 +283,7 @@ export class ShapeBuilder {
                     ].join(" ");
 
                     this.renderer.drawPath(path_roundRect, {
-                        fill: shapeProps.fill?.color,
+                        fill: shapeProps.fill,
                         stroke: shapeProps.stroke,
                         effect: shapeProps.effect,
                     });
@@ -326,7 +326,7 @@ export class ShapeBuilder {
                     }
 
                     this.renderer.drawPath(path_multi, {
-                        fill: shapeProps.fill?.color,
+                        fill: shapeProps.fill,
                         stroke: shapeProps.stroke,
                         effect: shapeProps.effect,
                     });

--- a/src/utils/svg-renderer.js
+++ b/src/utils/svg-renderer.js
@@ -138,8 +138,12 @@ export class SvgRenderer {
         }
 
         if (options.fill) {
-            if (typeof options.fill === 'object' && options.fill.type === 'gradient') {
-                rect.setAttribute('fill', this._createGradient(options.fill));
+            if (typeof options.fill === 'object') {
+                if (options.fill.type === 'gradient') {
+                    rect.setAttribute('fill', this._createGradient(options.fill));
+                } else if (options.fill.type === 'solid') {
+                    rect.setAttribute('fill', options.fill.color);
+                }
             } else {
                 rect.setAttribute('fill', options.fill);
             }
@@ -185,8 +189,12 @@ export class SvgRenderer {
         }
 
         if (options.fill) {
-            if (typeof options.fill === 'object' && options.fill.type === 'gradient') {
-                ellipse.setAttribute('fill', this._createGradient(options.fill));
+            if (typeof options.fill === 'object') {
+                if (options.fill.type === 'gradient') {
+                    ellipse.setAttribute('fill', this._createGradient(options.fill));
+                } else if (options.fill.type === 'solid') {
+                    ellipse.setAttribute('fill', options.fill.color);
+                }
             } else {
                 ellipse.setAttribute('fill', options.fill);
             }
@@ -349,8 +357,12 @@ export class SvgRenderer {
         }
 
         if (options.fill) {
-            if (typeof options.fill === 'object' && options.fill.type === 'gradient') {
-                path.setAttribute('fill', this._createGradient(options.fill));
+            if (typeof options.fill === 'object') {
+                if (options.fill.type === 'gradient') {
+                    path.setAttribute('fill', this._createGradient(options.fill));
+                } else if (options.fill.type === 'solid') {
+                    path.setAttribute('fill', options.fill.color);
+                }
             } else {
                 path.setAttribute('fill', options.fill);
             }

--- a/src/utils/svg-renderer.js
+++ b/src/utils/svg-renderer.js
@@ -57,6 +57,7 @@ export class SvgRenderer {
     }
 
     _createGradient(fillData) {
+        console.log("[DEBUG] Creating gradient with data:", JSON.stringify(fillData, null, 2));
         const gradientId = `grad-${this.defs.children.length}`;
         const gradient = document.createElementNS('http://www.w3.org/2000/svg', 'linearGradient');
         gradient.setAttribute('id', gradientId);

--- a/src/utils/svg-renderer.js
+++ b/src/utils/svg-renderer.js
@@ -56,6 +56,30 @@ export class SvgRenderer {
         // In SVG, effects are applied per-element, so a global reset is not needed.
     }
 
+    _createGradient(fillData) {
+        const gradientId = `grad-${this.defs.children.length}`;
+        const gradient = document.createElementNS('http://www.w3.org/2000/svg', 'linearGradient');
+        gradient.setAttribute('id', gradientId);
+        gradient.setAttribute('x1', '0%');
+        gradient.setAttribute('y1', '0%');
+        gradient.setAttribute('x2', '100%');
+        gradient.setAttribute('y2', '0%');
+        gradient.setAttribute('gradientTransform', `rotate(${fillData.gradient.angle})`);
+
+        fillData.gradient.stops.forEach(stop => {
+            const stopEl = document.createElementNS('http://www.w3.org/2000/svg', 'stop');
+            stopEl.setAttribute('offset', `${stop.pos * 100}%`);
+            stopEl.setAttribute('stop-color', stop.color.color);
+            if (stop.color.alpha < 1) {
+                stopEl.setAttribute('stop-opacity', stop.color.alpha);
+            }
+            gradient.appendChild(stopEl);
+        });
+
+        this.defs.appendChild(gradient);
+        return `url(#${gradientId})`;
+    }
+
     /**
      * Clears the SVG.
      */
@@ -113,7 +137,11 @@ export class SvgRenderer {
         }
 
         if (options.fill) {
-            rect.setAttribute('fill', options.fill);
+            if (typeof options.fill === 'object' && options.fill.type === 'gradient') {
+                rect.setAttribute('fill', this._createGradient(options.fill));
+            } else {
+                rect.setAttribute('fill', options.fill);
+            }
         } else {
             rect.setAttribute('fill', 'none');
         }
@@ -156,7 +184,11 @@ export class SvgRenderer {
         }
 
         if (options.fill) {
-            ellipse.setAttribute('fill', options.fill);
+            if (typeof options.fill === 'object' && options.fill.type === 'gradient') {
+                ellipse.setAttribute('fill', this._createGradient(options.fill));
+            } else {
+                ellipse.setAttribute('fill', options.fill);
+            }
         } else {
             ellipse.setAttribute('fill', 'none');
         }
@@ -316,7 +348,11 @@ export class SvgRenderer {
         }
 
         if (options.fill) {
-            path.setAttribute('fill', options.fill);
+            if (typeof options.fill === 'object' && options.fill.type === 'gradient') {
+                path.setAttribute('fill', this._createGradient(options.fill));
+            } else {
+                path.setAttribute('fill', options.fill);
+            }
         } else {
             path.setAttribute('fill', 'none');
         }

--- a/src/utils/svg-renderer.js
+++ b/src/utils/svg-renderer.js
@@ -64,7 +64,7 @@ export class SvgRenderer {
         gradient.setAttribute('y1', '0%');
         gradient.setAttribute('x2', '100%');
         gradient.setAttribute('y2', '0%');
-        gradient.setAttribute('gradientTransform', `rotate(${fillData.gradient.angle})`);
+        gradient.setAttribute('gradientTransform', `rotate(${fillData.gradient.angle}, 0.5, 0.5)`);
 
         fillData.gradient.stops.forEach(stop => {
             const stopEl = document.createElementNS('http://www.w3.org/2000/svg', 'stop');


### PR DESCRIPTION
feat: Implement parsing and rendering of gradient fills

This commit introduces support for parsing and rendering gradient fills for shapes and slide backgrounds.

- Modified `index.html` to parse `<a:gradFill>` elements in slide backgrounds, shapes, and themes.
- Created a `parseGradientFill` helper function to handle the parsing of gradient properties, including stops, angle, and type.
- Updated `resolveColor` to return color and alpha components separately, which is necessary for SVG gradient stops.
- Modified `SvgRenderer` to create `<linearGradient>` elements in the SVG `<defs>` section.
- Updated the drawing methods (`drawRect`, `drawEllipse`, `drawPath`) in `SvgRenderer` to use the newly created gradients.