### PR TITLE
Feature/add svg element ids

### DIFF
--- a/src/slideHandler.js
+++ b/src/slideHandler.js
@@ -190,8 +190,8 @@ export class SlideHandler {
         return shapes;
     }
 
-    async renderShapeTree(shapes) {
-        shapes.forEach(async (shapeData, index) => {
+    async renderShapeTree(shapes = []) {
+        for (const [index, shapeData] of shapes.entries()) {
             const id = `${this.slideId}.shapes.${index}`;
             switch (shapeData.type) {
                 case 'shape':
@@ -210,7 +210,7 @@ export class SlideHandler {
                     await this.renderPicture(shapeData, id);
                     break;
             }
-        });
+        };
     }
 
     async parseShape(shapeNode, listCounters, parentMatrix, slideLevelVisibility) {
@@ -460,7 +460,8 @@ export class SlideHandler {
 
         if (picData.image) {
             const imageEl = document.createElementNS('http://www.w3.org/2000/svg', 'image');
-            imageEl.setAttribute('href', picData.image.href);
+            imageEl.setAttribute( 'href', picData.image.href );
+            imageEl.setAttribute( 'id', `${id}.image` );
 
             if (picData.image.srcRect) {
                 const img = await createImage(picData.image.href);
@@ -571,8 +572,8 @@ export class SlideHandler {
         this.renderer.setTransform(matrix, id);
 
         for (const [index, cell] of tableData.cells.entries()) {
-            const cellId = `${id}.cell.${index}`;
-            this.renderer.drawRect(cell.pos.x, cell.pos.y, cell.pos.width, cell.pos.height, { fill: cell.fill || 'transparent' });
+            const cellId = `${id}.cells.${index}`;
+            this.renderer.drawRect(cell.pos.x, cell.pos.y, cell.pos.width, cell.pos.height, { fill: cell.fill || 'transparent', id: cellId });
 
             const { x, y, width, height } = cell.pos;
             if (cell.borders.top) this.renderer.drawLine(x, y, x + width, y, { stroke: cell.borders.top });

--- a/src/slideshowDataStore.js
+++ b/src/slideshowDataStore.js
@@ -29,10 +29,9 @@ function presentationReducer( state = initialPresentationState, action ) {
 }
 
 const initialSlideState = {
-    slideNum: -1,
-    shapes: [],
-    background: null,
-    slideContext: null,
+    id: '',
+    parsingData: null,
+    renderingData: null
 };
 
 export const presentationStore = new ReactiveStore( {

--- a/src/slideshowHandler.js
+++ b/src/slideshowHandler.js
@@ -182,7 +182,7 @@ export async function slideshowHandler( { file, slideViewerContainer, slideSelec
 
             slideStores.set( slideId, createSlideStore( {
                 id: slideId,
-                state: { parsingData }
+                state: { id: slideId, parsingData }
             } ) );
 
             const pptxHandler = new SlideHandler( { ...parsingData, ...staticParsingData } );
@@ -190,7 +190,7 @@ export async function slideshowHandler( { file, slideViewerContainer, slideSelec
 
             const slide = slideStores.get( slideId );
             slide.dispatch( { type: actions.set.slide.data, payload: { renderingData } } );
-            console.log({ slide: slide.getState( 'renderingData' ) })
+            console.log({ slide: slide.getState() })
 
             if ( presentationStore.getState( 'status' ) !== 'rendering' ) {
                 presentationStore.dispatch( { type: actions.start.rendering } );

--- a/src/utils/svgRenderer.js
+++ b/src/utils/svgRenderer.js
@@ -56,9 +56,12 @@ export class SvgRenderer {
         // In SVG, effects are applied per-element, so a global reset is not needed.
     }
 
-    _createGradient(fillData) {
+    _createGradient(fillData, id) {
         const gradientId = `grad-${this.defs.children.length}`;
-        const gradient = document.createElementNS('http://www.w3.org/2000/svg', 'linearGradient');
+        const gradient = document.createElementNS( 'http://www.w3.org/2000/svg', 'linearGradient' );
+        if ( id ) {
+            gradient.setAttribute( 'id', options.id );
+        }
         gradient.setAttribute('id', gradientId);
         gradient.setAttribute('x1', '0%');
         gradient.setAttribute('y1', '0%');
@@ -115,7 +118,10 @@ export class SvgRenderer {
      * @param {object} [options] - The rendering options.
      */
     drawRect(x, y, width, height, options = {}) {
-        const rect = document.createElementNS('http://www.w3.org/2000/svg', 'rect');
+        const rect = document.createElementNS( 'http://www.w3.org/2000/svg', 'rect' );
+        if ( options.id ) {
+            rect.setAttribute( 'id', cellId );
+        }
 
         const strokeWidth = (options.stroke && options.stroke.width > 0) ? options.stroke.width : 0;
 
@@ -180,7 +186,10 @@ export class SvgRenderer {
      * @param {object} [options] - The rendering options.
      */
     drawEllipse(cx, cy, rx, ry, options = {}) {
-        const ellipse = document.createElementNS('http://www.w3.org/2000/svg', 'ellipse');
+        const ellipse = document.createElementNS( 'http://www.w3.org/2000/svg', 'ellipse' );
+        if ( options.id ) {
+            ellipse.setAttribute( 'id', options.id );
+        }
         ellipse.setAttribute('cx', cx);
         ellipse.setAttribute('cy', cy);
         ellipse.setAttribute('rx', rx);
@@ -319,7 +328,10 @@ export class SvgRenderer {
             if (options.stroke.cmpd && options.stroke.cmpd !== 'sng') {
                 this._drawCompoundLine(x1, y1, x2, y2, options);
             } else {
-                 const line = document.createElementNS('http://www.w3.org/2000/svg', 'line');
+                const line = document.createElementNS( 'http://www.w3.org/2000/svg', 'line' );
+                if ( options.id ) {
+                    line.setAttribute( 'id', options.id );
+                }
                 line.setAttribute('x1', x1);
                 line.setAttribute('y1', y1);
                 line.setAttribute('x2', x2);

--- a/src/utils/svgRenderer.js
+++ b/src/utils/svgRenderer.js
@@ -94,9 +94,13 @@ export class SvgRenderer {
     /**
      * Sets the transformation for subsequent shapes.
      * @param {Matrix} matrix - The transformation matrix.
+     * @param {string} id - The ID to assign to the group element.
      */
-    setTransform(matrix) {
+    setTransform(matrix, id) {
         const g = document.createElementNS('http://www.w3.org/2000/svg', 'g');
+        if (id) {
+            g.setAttribute('id', id);
+        }
         g.setAttribute('transform', `matrix(${matrix.m.join(' ')})`);
         this.svg.appendChild(g);
         this.currentGroup = g;
@@ -395,6 +399,9 @@ export class SvgRenderer {
      */
     drawText(textContent, x, y, options = {}) {
         const text = document.createElementNS('http://www.w3.org/2000/svg', 'text');
+        if (options.id) {
+            text.setAttribute('id', options.id);
+        }
         text.setAttribute('x', x);
         text.setAttribute('y', y);
         text.textContent = textContent;


### PR DESCRIPTION
feat: Assign IDs to rendered SVG elements

This change assigns unique IDs to all SVG elements rendered by the SlideHandler. The IDs correspond to the path of the data used to render that element.

For example:
- The slide's background has the ID "SlideID1.background".
- A shape on the slide has the ID "SlideID1.shapes.0".
- Text within a shape has the ID "SlideID1.shapes.0.text".
- A cell in a table has the ID "SlideID1.shapes.1.cell.0".

This is achieved by:
- Modifying `SvgRenderer.setTransform` and `SvgRenderer.drawText` to accept an ID.
- Updating `SlideHandler.renderShapeTree` to generate and propagate these IDs to the various rendering methods.
- Implementing ID assignment in shape-specific rendering methods (`renderShape`, `renderTable`, `renderChart`, `renderPicture`, `renderParagraphs`).